### PR TITLE
Add solid/no-proxy-apis rule for envs that don't support ES6 Proxy.

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ const [editedValue, setEditedValue] = createSignal(props.value);
 | ✔ |  | [solid/jsx-uses-vars](docs/jsx-uses-vars.md) | Prevent variables used in JSX from being marked as unused. |
 | ✔ | 🔧 | [solid/no-destructure](docs/no-destructure.md) | Disallow destructuring props. In Solid, props must be used with property accesses (`props.foo`) to preserve reactivity. This rule only tracks destructuring in the parameter list. |
 | ✔ | 🔧 | [solid/no-innerhtml](docs/no-innerhtml.md) | Disallow usage of the innerHTML attribute, which can often lead to security vulnerabilities. |
-| ✔ |  | [solid/no-proxy-apis](docs/no-proxy-apis.md) | Disallow usage of APIs that use ES6 Proxies, to target environments that don't support them. |
+| ✔ |  | [solid/no-proxy-apis](docs/no-proxy-apis.md) | Disallow usage of APIs that use ES6 Proxies, only to target environments that don't support them. |
 | ✔ | 🔧 | [solid/no-react-specific-props](docs/no-react-specific-props.md) | Disallow usage of React-specific `className`/`htmlFor` props, which were deprecated in v1.4.0. |
 | ✔ |  | [solid/no-unknown-namespaces](docs/no-unknown-namespaces.md) | Enforce using only Solid-specific namespaced attribute names (i.e. `'on:'` in `<div on:click={...} />`). |
 | ✔ | 🔧 | [solid/prefer-classlist](docs/prefer-classlist.md) | Enforce using the classlist prop over importing a classnames helper. The classlist prop accepts an object `{ [class: string]: boolean }` just like classnames. |

--- a/README.md
+++ b/README.md
@@ -119,27 +119,26 @@ const [editedValue, setEditedValue] = createSignal(props.value);
 🔧: Fixable with [`eslint --fix`](https://eslint.org/docs/user-guide/command-line-interface#fixing-problems)/IDE auto-fix.
 
 <!-- AUTO-GENERATED-CONTENT:START (RULES) -->
-
-|  ✔  | 🔧  | Rule                                                             | Description                                                                                                                                                                                                                           |
-| :-: | :-: | :--------------------------------------------------------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-|  ✔  | 🔧  | [solid/components-return-once](docs/components-return-once.md)   | Disallow early returns in components. Solid components only run once, and so conditionals should be inside JSX.                                                                                                                       |
-|  ✔  | 🔧  | [solid/event-handlers](docs/event-handlers.md)                   | Enforce naming DOM element event handlers consistently and prevent Solid's analysis from misunderstanding whether a prop should be an event handler.                                                                                  |
-|  ✔  | 🔧  | [solid/imports](docs/imports.md)                                 | Enforce consistent imports from "solid-js", "solid-js/web", and "solid-js/store".                                                                                                                                                     |
-|  ✔  |     | [solid/jsx-no-duplicate-props](docs/jsx-no-duplicate-props.md)   | Disallow passing the same prop twice in JSX.                                                                                                                                                                                          |
-|  ✔  |     | [solid/jsx-no-script-url](docs/jsx-no-script-url.md)             | Disallow javascript: URLs.                                                                                                                                                                                                            |
-|  ✔  | 🔧  | [solid/jsx-no-undef](docs/jsx-no-undef.md)                       | Disallow references to undefined variables in JSX. Handles custom directives.                                                                                                                                                         |
-|  ✔  |     | [solid/jsx-uses-vars](docs/jsx-uses-vars.md)                     | Prevent variables used in JSX from being marked as unused.                                                                                                                                                                            |
-|  ✔  | 🔧  | [solid/no-destructure](docs/no-destructure.md)                   | Disallow destructuring props. In Solid, props must be used with property accesses (`props.foo`) to preserve reactivity. This rule only tracks destructuring in the parameter list.                                                    |
-|  ✔  | 🔧  | [solid/no-innerhtml](docs/no-innerhtml.md)                       | Disallow usage of the innerHTML attribute, which can often lead to security vulnerabilities.                                                                                                                                          |
-|  ✔  | 🔧  | [solid/no-react-specific-props](docs/no-react-specific-props.md) | Disallow usage of React-specific `className`/`htmlFor` props, which were deprecated in v1.4.0.                                                                                                                                        |
-|  ✔  |     | [solid/no-unknown-namespaces](docs/no-unknown-namespaces.md)     | Enforce using only Solid-specific namespaced attribute names (i.e. `'on:'` in `<div on:click={...} />`).                                                                                                                              |
-|  ✔  | 🔧  | [solid/prefer-classlist](docs/prefer-classlist.md)               | Enforce using the classlist prop over importing a classnames helper. The classlist prop accepts an object `{ [class: string]: boolean }` just like classnames.                                                                        |
-|  ✔  | 🔧  | [solid/prefer-for](docs/prefer-for.md)                           | Enforce using Solid's `<For />` component for mapping an array to JSX elements.                                                                                                                                                       |
-|  ✔  | 🔧  | [solid/prefer-show](docs/prefer-show.md)                         | Enforce using Solid's `<Show />` component for conditionally showing content. Solid's compiler covers this case, so it's a stylistic rule only.                                                                                       |
-|  ✔  |     | [solid/reactivity](docs/reactivity.md)                           | Enforce that reactive expressions (props, signals, memos, etc.) are only used in tracked scopes; otherwise, they won't update the view as expected.                                                                                   |
-|  ✔  | 🔧  | [solid/self-closing-comp](docs/self-closing-comp.md)             | Disallow extra closing tags for components without children.                                                                                                                                                                          |
-|  ✔  | 🔧  | [solid/style-prop](docs/style-prop.md)                           | Require CSS properties in the `style` prop to be valid and kebab-cased (ex. 'font-size'), not camel-cased (ex. 'fontSize') like in React, and that property values with dimensions are strings, not numbers with implicit 'px' units. |
-
+| ✔ | 🔧 | Rule | Description |
+| :---: | :---: | :--- | :--- |
+| ✔ | 🔧 | [solid/components-return-once](docs/components-return-once.md) | Disallow early returns in components. Solid components only run once, and so conditionals should be inside JSX. |
+| ✔ | 🔧 | [solid/event-handlers](docs/event-handlers.md) | Enforce naming DOM element event handlers consistently and prevent Solid's analysis from misunderstanding whether a prop should be an event handler. |
+| ✔ | 🔧 | [solid/imports](docs/imports.md) | Enforce consistent imports from "solid-js", "solid-js/web", and "solid-js/store". |
+| ✔ |  | [solid/jsx-no-duplicate-props](docs/jsx-no-duplicate-props.md) | Disallow passing the same prop twice in JSX. |
+| ✔ |  | [solid/jsx-no-script-url](docs/jsx-no-script-url.md) | Disallow javascript: URLs. |
+| ✔ | 🔧 | [solid/jsx-no-undef](docs/jsx-no-undef.md) | Disallow references to undefined variables in JSX. Handles custom directives. |
+| ✔ |  | [solid/jsx-uses-vars](docs/jsx-uses-vars.md) | Prevent variables used in JSX from being marked as unused. |
+| ✔ | 🔧 | [solid/no-destructure](docs/no-destructure.md) | Disallow destructuring props. In Solid, props must be used with property accesses (`props.foo`) to preserve reactivity. This rule only tracks destructuring in the parameter list. |
+| ✔ | 🔧 | [solid/no-innerhtml](docs/no-innerhtml.md) | Disallow usage of the innerHTML attribute, which can often lead to security vulnerabilities. |
+| ✔ |  | [solid/no-proxy-apis](docs/no-proxy-apis.md) | Disallow usage of APIs that use ES6 Proxies, to target environments that don't support them. |
+| ✔ | 🔧 | [solid/no-react-specific-props](docs/no-react-specific-props.md) | Disallow usage of React-specific `className`/`htmlFor` props, which were deprecated in v1.4.0. |
+| ✔ |  | [solid/no-unknown-namespaces](docs/no-unknown-namespaces.md) | Enforce using only Solid-specific namespaced attribute names (i.e. `'on:'` in `<div on:click={...} />`). |
+| ✔ | 🔧 | [solid/prefer-classlist](docs/prefer-classlist.md) | Enforce using the classlist prop over importing a classnames helper. The classlist prop accepts an object `{ [class: string]: boolean }` just like classnames. |
+| ✔ | 🔧 | [solid/prefer-for](docs/prefer-for.md) | Enforce using Solid's `<For />` component for mapping an array to JSX elements. |
+| ✔ | 🔧 | [solid/prefer-show](docs/prefer-show.md) | Enforce using Solid's `<Show />` component for conditionally showing content. Solid's compiler covers this case, so it's a stylistic rule only. |
+| ✔ |  | [solid/reactivity](docs/reactivity.md) | Enforce that reactive expressions (props, signals, memos, etc.) are only used in tracked scopes; otherwise, they won't update the view as expected. |
+| ✔ | 🔧 | [solid/self-closing-comp](docs/self-closing-comp.md) | Disallow extra closing tags for components without children. |
+| ✔ | 🔧 | [solid/style-prop](docs/style-prop.md) | Require CSS properties in the `style` prop to be valid and kebab-cased (ex. 'font-size'), not camel-cased (ex. 'fontSize') like in React, and that property values with dimensions are strings, not numbers with implicit 'px' units. |
 <!-- AUTO-GENERATED-CONTENT:END -->
 
 ## Versioning
@@ -149,10 +148,8 @@ stable across patch (`0.0.x`) versions, but may change across minor (`0.x`) vers
 If you want to pin a minor version, use a tilde in your `package.json`.
 
 <!-- AUTO-GENERATED-CONTENT:START (TILDE) -->
-
 ```diff
 - "eslint-plugin-solid": "^0.7.4"
 + "eslint-plugin-solid": "~0.7.4"
 ```
-
 <!-- AUTO-GENERATED-CONTENT:END -->

--- a/docs/no-proxy-apis.md
+++ b/docs/no-proxy-apis.md
@@ -1,0 +1,114 @@
+<!-- AUTO-GENERATED-CONTENT:START (HEADER) -->
+# solid/no-proxy-apis
+Disallow usage of APIs that use ES6 Proxies, only to target environments that don't support them.
+This rule is **off** by default.
+
+[View source](../src/rules/no-proxy-apis.ts) · [View tests](../test/rules/no-proxy-apis.test.ts)
+
+<!-- AUTO-GENERATED-CONTENT:END -->
+
+<!-- AUTO-GENERATED-CONTENT:START (OPTIONS) -->
+ 
+<!-- AUTO-GENERATED-CONTENT:END -->
+
+<!-- AUTO-GENERATED-CONTENT:START (CASES) -->
+## Tests
+
+### Invalid Examples
+
+These snippets cause lint errors, and some can be auto-fixed.
+
+```js
+let el = <div className="greeting">Hello world!</div>;
+// after eslint --fix:
+let el = <div class="greeting">Hello world!</div>;
+ 
+let el = <div className={"greeting"}>Hello world!</div>;
+// after eslint --fix:
+let el = <div class={"greeting"}>Hello world!</div>;
+ 
+let el = <div className="greeting" />;
+// after eslint --fix:
+let el = <div class="greeting" />;
+ 
+let el = (
+  <div many other attributes className="greeting">
+    Hello world!
+  </div>
+);
+// after eslint --fix:
+let el = (
+  <div many other attributes class="greeting">
+    Hello world!
+  </div>
+);
+ 
+let el = <PascalComponent className="greeting">Hello world!</PascalComponent>;
+// after eslint --fix:
+let el = <PascalComponent class="greeting">Hello world!</PascalComponent>;
+ 
+let el = <label htmlFor="id">Hello world!</label>;
+// after eslint --fix:
+let el = <label for="id">Hello world!</label>;
+ 
+let el = <label htmlFor={"id"}>Hello world!</label>;
+// after eslint --fix:
+let el = <label for={"id"}>Hello world!</label>;
+ 
+let el = (
+  <label many other attributes htmlFor="id">
+    Hello world!
+  </label>
+);
+// after eslint --fix:
+let el = (
+  <label many other attributes for="id">
+    Hello world!
+  </label>
+);
+ 
+let el = <PascalComponent htmlFor="id">Hello world!</PascalComponent>;
+// after eslint --fix:
+let el = <PascalComponent for="id">Hello world!</PascalComponent>;
+ 
+let el = <div key={item.id} />;
+// after eslint --fix:
+let el = <div />;
+ 
+```
+
+### Valid Examples
+
+These snippets don't cause lint errors.
+
+```js
+let el = <div>Hello world!</div>;
+
+let el = <div class="greeting">Hello world!</div>;
+
+let el = <div class={"greeting"}>Hello world!</div>;
+
+let el = (
+  <div many other attributes class="greeting">
+    Hello world!
+  </div>
+);
+
+let el = <label for="id">Hello world!</label>;
+
+let el = <label for="id">Hello world!</label>;
+
+let el = <label for={"id"}>Hello world!</label>;
+
+let el = (
+  <label many other attributes for="id">
+    Hello world!
+  </label>
+);
+
+let el = <PascalComponent class="greeting" for="id" />;
+
+let el = <PascalComponent key={item.id} />;
+
+```
+<!-- AUTO-GENERATED-CONTENT:END -->

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ import jsxNoUndef from "./rules/jsx-no-undef";
 import jsxUsesVars from "./rules/jsx-uses-vars";
 import noDestructure from "./rules/no-destructure";
 import noInnerHTML from "./rules/no-innerhtml";
+import noProxyApis from "./rules/no-proxy-apis";
 import noReactSpecificProps from "./rules/no-react-specific-props";
 import noUnknownNamespaces from "./rules/no-unknown-namespaces";
 import preferClasslist from "./rules/prefer-classlist";
@@ -27,6 +28,7 @@ const allRules = {
   "jsx-uses-vars": jsxUsesVars,
   "no-destructure": noDestructure,
   "no-innerhtml": noInnerHTML,
+  "no-proxy-apis": noProxyApis,
   "no-react-specific-props": noReactSpecificProps,
   "no-unknown-namespaces": noUnknownNamespaces,
   "prefer-classlist": preferClasslist,
@@ -79,6 +81,8 @@ const plugin = {
         "solid/self-closing-comp": 1,
         // handled by Solid compiler, opt-in style suggestion
         "solid/prefer-show": 0,
+        // only necessary for resource-constrained environments
+        "solid/no-proxy-apis": 0,
       },
     },
     typescript: {
@@ -111,6 +115,8 @@ const plugin = {
         "solid/no-unknown-namespaces": 0,
         // handled by Solid compiler, opt-in style suggestion
         "solid/prefer-show": 0,
+        // only necessary for resource-constrained environments
+        "solid/no-proxy-apis": 0,
       },
     },
   },

--- a/src/rules/no-proxy-apis.ts
+++ b/src/rules/no-proxy-apis.ts
@@ -10,7 +10,7 @@ const rule: TSESLint.RuleModule<
     docs: {
       recommended: false,
       description:
-        "Disallow usage of APIs that use ES6 Proxies, to target environments that don't support them.",
+        "Disallow usage of APIs that use ES6 Proxies, only to target environments that don't support them.",
       url: "https://github.com/solidjs-community/eslint-plugin-solid/blob/main/docs/no-proxy-apis.md",
     },
     schema: [],

--- a/src/rules/no-proxy-apis.ts
+++ b/src/rules/no-proxy-apis.ts
@@ -1,0 +1,91 @@
+import { TSESTree as T, TSESLint } from "@typescript-eslint/utils";
+import { isFunctionNode, trackImports, isPropsByName, trace } from "../utils";
+
+const rule: TSESLint.RuleModule<
+  "noStore" | "spreadCall" | "spreadMember" | "proxyLiteral" | "mergeProps",
+  []
+> = {
+  meta: {
+    type: "problem",
+    docs: {
+      recommended: false,
+      description:
+        "Disallow usage of APIs that use ES6 Proxies, to target environments that don't support them.",
+      url: "https://github.com/solidjs-community/eslint-plugin-solid/blob/main/docs/no-proxy-apis.md",
+    },
+    schema: [],
+    messages: {
+      noStore: "Solid Store APIs use Proxies, which are incompatible with your target environment.",
+      spreadCall:
+        "Using a function call in JSX spread makes Solid use Proxies, which are incompatible with your target environment.",
+      spreadMember:
+        "Using a property access in JSX spread makes Solid use Proxies, which are incompatible with your target environment.",
+      proxyLiteral: "Proxies are incompatible with your target environment.",
+      mergeProps:
+        "If you pass a function to `mergeProps`, it will create a Proxy, which are incompatible with your target environment.",
+    },
+  },
+  create(context) {
+    const { matchImport, handleImportDeclaration } = trackImports();
+
+    return {
+      ImportDeclaration(node) {
+        handleImportDeclaration(node); // track import aliases
+
+        const source = node.source.value;
+        if (source === "solid-js/store") {
+          context.report({
+            node,
+            messageId: "noStore",
+          });
+        }
+      },
+      "JSXSpreadAttribute MemberExpression"(node: T.MemberExpression) {
+        context.report({ node, messageId: "spreadMember" });
+      },
+      "JSXSpreadAttribute CallExpression"(node: T.CallExpression) {
+        context.report({ node, messageId: "spreadCall" });
+      },
+      CallExpression(node) {
+        if (node.callee.type === "Identifier") {
+          if (matchImport("mergeProps", node.callee.name)) {
+            node.arguments
+              .filter((arg) => {
+                if (arg.type === "SpreadElement") return true;
+                const traced = trace(arg, context.getScope());
+                return (
+                  (traced.type === "Identifier" && !isPropsByName(traced.name)) ||
+                  isFunctionNode(traced)
+                );
+              })
+              .forEach((badArg) => {
+                context.report({
+                  node: badArg,
+                  messageId: "mergeProps",
+                });
+              });
+          }
+        } else if (node.callee.type === "MemberExpression") {
+          if (
+            node.callee.object.type === "Identifier" &&
+            node.callee.object.name === "Proxy" &&
+            node.callee.property.type === "Identifier" &&
+            node.callee.property.name === "revocable"
+          ) {
+            context.report({
+              node,
+              messageId: "proxyLiteral",
+            });
+          }
+        }
+      },
+      NewExpression(node) {
+        if (node.callee.type === "Identifier" && node.callee.name === "Proxy") {
+          context.report({ node, messageId: "proxyLiteral" });
+        }
+      },
+    };
+  },
+};
+
+export default rule;

--- a/test/rules/no-proxy-apis.test.ts
+++ b/test/rules/no-proxy-apis.test.ts
@@ -1,0 +1,69 @@
+import { AST_NODE_TYPES as T } from "@typescript-eslint/utils";
+import { run } from "../ruleTester";
+import rule from "../../src/rules/no-proxy-apis";
+
+// Don't bother checking for imports for every test
+jest.mock("../../src/utils", () => {
+  return {
+    ...jest.requireActual("../../src/utils"),
+    trackImports: () => {
+      // eslint-disable-next-line @typescript-eslint/no-empty-function
+      const handleImportDeclaration = () => {};
+      const matchImport = (imports: string | Array<string>, str: string) => {
+        const importArr = Array.isArray(imports) ? imports : [imports];
+        return importArr.find((i) => i === str);
+      };
+      return { matchImport, handleImportDeclaration };
+    },
+  };
+});
+
+export const cases = run("no-proxy-apis", rule, {
+  valid: [
+    `let merged = mergeProps({}, props);`,
+    `const obj = {}; let merged = mergeProps(obj, props);`,
+    `let obj = {}; let merged = mergeProps(obj, props);`,
+    `let merged = mergeProps({ get asdf() { signal() } }, props);`,
+    `let el = <div {...{ asdf: 'asdf' }} />`,
+    `let el = <div {...asdf} />`,
+    `let obj = { Proxy: 1 }`,
+  ],
+  invalid: [
+    {
+      code: `let proxy = new Proxy(asdf, {});`,
+      errors: [{ messageId: "proxyLiteral" }],
+    },
+    {
+      code: `let proxy = Proxy.revocable(asdf, {});`,
+      errors: [{ messageId: "proxyLiteral" }],
+    },
+    {
+      code: `import {} from 'solid-js/store';`,
+      errors: [{ messageId: "noStore", type: T.ImportDeclaration }],
+    },
+    {
+      code: `let el = <div {...maybeSignal()} />`,
+      errors: [{ messageId: "spreadCall" }],
+    },
+    {
+      code: `let el = <div {...{ ...maybeSignal() }} />`,
+      errors: [{ messageId: "spreadCall" }],
+    },
+    {
+      code: `let el = <div {...maybeProps.foo} />`,
+      errors: [{ messageId: "spreadMember" }],
+    },
+    {
+      code: `let el = <div {...{ ...maybeProps.foo }} />`,
+      errors: [{ messageId: "spreadMember" }],
+    },
+    {
+      code: `let merged = mergeProps(maybeSignal)`,
+      errors: [{ messageId: "mergeProps" }],
+    },
+    {
+      code: `let func = () => ({}); let merged = mergeProps(func, props)`,
+      errors: [{ messageId: "mergeProps" }],
+    },
+  ],
+});

--- a/test/rules/reactivity.test.ts
+++ b/test/rules/reactivity.test.ts
@@ -11,7 +11,7 @@ jest.mock("../../src/utils", () => {
       const handleImportDeclaration = () => {};
       const matchImport = (imports: string | Array<string>, str: string) => {
         const importArr = Array.isArray(imports) ? imports : [imports];
-        return importArr.includes(str);
+        return importArr.find((i) => i === str);
       };
       return { matchImport, handleImportDeclaration };
     },


### PR DESCRIPTION
Solid 1.6 adds changes to JSX spreads on native elements, `mergeProps`, and `splitProps` to bypass creating Proxies when possible, which makes Solid viable for targeting environments that don't support Proxies. However, certain cases will still force creation of Proxies, and it's not obvious when this happens. Following [this thread](https://twitter.com/cakemakerjake/status/1583049918616285185?s=20&t=SSJ1Aa-Ah3NjzeM2Sk4qZg), I'm adding an opt-in rule that will catch these cases in first-party code to help people avoid accidentally using Proxies.