### PR TITLE
In components-return-once, don't treat callback functions as components.

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,27 +119,25 @@ const [editedValue, setEditedValue] = createSignal(props.value);
 🔧: Fixable with [`eslint --fix`](https://eslint.org/docs/user-guide/command-line-interface#fixing-problems)/IDE auto-fix.
 
 <!-- AUTO-GENERATED-CONTENT:START (RULES) -->
-
-|  ✔  | 🔧  | Rule                                                             | Description                                                                                                                                                                                                                           |
-| :-: | :-: | :--------------------------------------------------------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-|  ✔  | 🔧  | [solid/components-return-once](docs/components-return-once.md)   | Disallow early returns in components. Solid components only run once, and so conditionals should be inside JSX.                                                                                                                       |
-|  ✔  | 🔧  | [solid/event-handlers](docs/event-handlers.md)                   | Enforce naming DOM element event handlers consistently and prevent Solid's analysis from misunderstanding whether a prop should be an event handler.                                                                                  |
-|  ✔  | 🔧  | [solid/imports](docs/imports.md)                                 | Enforce consistent imports from "solid-js", "solid-js/web", and "solid-js/store".                                                                                                                                                     |
-|  ✔  |     | [solid/jsx-no-duplicate-props](docs/jsx-no-duplicate-props.md)   | Disallow passing the same prop twice in JSX.                                                                                                                                                                                          |
-|  ✔  |     | [solid/jsx-no-script-url](docs/jsx-no-script-url.md)             | Disallow javascript: URLs.                                                                                                                                                                                                            |
-|  ✔  | 🔧  | [solid/jsx-no-undef](docs/jsx-no-undef.md)                       | Disallow references to undefined variables in JSX. Handles custom directives.                                                                                                                                                         |
-|  ✔  |     | [solid/jsx-uses-vars](docs/jsx-uses-vars.md)                     | Prevent variables used in JSX from being marked as unused.                                                                                                                                                                            |
-|  ✔  | 🔧  | [solid/no-destructure](docs/no-destructure.md)                   | Disallow destructuring props. In Solid, props must be used with property accesses (`props.foo`) to preserve reactivity. This rule only tracks destructuring in the parameter list.                                                    |
-|  ✔  | 🔧  | [solid/no-innerhtml](docs/no-innerhtml.md)                       | Disallow usage of the innerHTML attribute, which can often lead to security vulnerabilities.                                                                                                                                          |
-|  ✔  | 🔧  | [solid/no-react-specific-props](docs/no-react-specific-props.md) | Disallow usage of React-specific `className`/`htmlFor` props, which were deprecated in v1.4.0.                                                                                                                                        |
-|  ✔  |     | [solid/no-unknown-namespaces](docs/no-unknown-namespaces.md)     | Enforce using only Solid-specific namespaced attribute names (i.e. `'on:'` in `<div on:click={...} />`).                                                                                                                              |
-|  ✔  | 🔧  | [solid/prefer-classlist](docs/prefer-classlist.md)               | Enforce using the classlist prop over importing a classnames helper. The classlist prop accepts an object `{ [class: string]: boolean }` just like classnames.                                                                        |
-|  ✔  | 🔧  | [solid/prefer-for](docs/prefer-for.md)                           | Enforce using Solid's `<For />` component for mapping an array to JSX elements.                                                                                                                                                       |
-|  ✔  | 🔧  | [solid/prefer-show](docs/prefer-show.md)                         | Enforce using Solid's `<Show />` component for conditionally showing content. Solid's compiler covers this case, so it's a stylistic rule only.                                                                                       |
-|  ✔  |     | [solid/reactivity](docs/reactivity.md)                           | Enforce that reactive expressions (props, signals, memos, etc.) are only used in tracked scopes; otherwise, they won't update the view as expected.                                                                                   |
-|  ✔  | 🔧  | [solid/self-closing-comp](docs/self-closing-comp.md)             | Disallow extra closing tags for components without children.                                                                                                                                                                          |
-|  ✔  | 🔧  | [solid/style-prop](docs/style-prop.md)                           | Require CSS properties in the `style` prop to be valid and kebab-cased (ex. 'font-size'), not camel-cased (ex. 'fontSize') like in React, and that property values with dimensions are strings, not numbers with implicit 'px' units. |
-
+| ✔ | 🔧 | Rule | Description |
+| :---: | :---: | :--- | :--- |
+| ✔ | 🔧 | [solid/components-return-once](docs/components-return-once.md) | Disallow early returns in components. Solid components only run once, and so conditionals should be inside JSX. |
+| ✔ | 🔧 | [solid/event-handlers](docs/event-handlers.md) | Enforce naming DOM element event handlers consistently and prevent Solid's analysis from misunderstanding whether a prop should be an event handler. |
+| ✔ | 🔧 | [solid/imports](docs/imports.md) | Enforce consistent imports from "solid-js", "solid-js/web", and "solid-js/store". |
+| ✔ |  | [solid/jsx-no-duplicate-props](docs/jsx-no-duplicate-props.md) | Disallow passing the same prop twice in JSX. |
+| ✔ |  | [solid/jsx-no-script-url](docs/jsx-no-script-url.md) | Disallow javascript: URLs. |
+| ✔ | 🔧 | [solid/jsx-no-undef](docs/jsx-no-undef.md) | Disallow references to undefined variables in JSX. Handles custom directives. |
+| ✔ |  | [solid/jsx-uses-vars](docs/jsx-uses-vars.md) | Prevent variables used in JSX from being marked as unused. |
+| ✔ | 🔧 | [solid/no-destructure](docs/no-destructure.md) | Disallow destructuring props. In Solid, props must be used with property accesses (`props.foo`) to preserve reactivity. This rule only tracks destructuring in the parameter list. |
+| ✔ | 🔧 | [solid/no-innerhtml](docs/no-innerhtml.md) | Disallow usage of the innerHTML attribute, which can often lead to security vulnerabilities. |
+| ✔ | 🔧 | [solid/no-react-specific-props](docs/no-react-specific-props.md) | Disallow usage of React-specific `className`/`htmlFor` props, which were deprecated in v1.4.0. |
+| ✔ |  | [solid/no-unknown-namespaces](docs/no-unknown-namespaces.md) | Enforce using only Solid-specific namespaced attribute names (i.e. `'on:'` in `<div on:click={...} />`). |
+| ✔ | 🔧 | [solid/prefer-classlist](docs/prefer-classlist.md) | Enforce using the classlist prop over importing a classnames helper. The classlist prop accepts an object `{ [class: string]: boolean }` just like classnames. |
+| ✔ | 🔧 | [solid/prefer-for](docs/prefer-for.md) | Enforce using Solid's `<For />` component for mapping an array to JSX elements. |
+| ✔ | 🔧 | [solid/prefer-show](docs/prefer-show.md) | Enforce using Solid's `<Show />` component for conditionally showing content. Solid's compiler covers this case, so it's a stylistic rule only. |
+| ✔ |  | [solid/reactivity](docs/reactivity.md) | Enforce that reactive expressions (props, signals, memos, etc.) are only used in tracked scopes; otherwise, they won't update the view as expected. |
+| ✔ | 🔧 | [solid/self-closing-comp](docs/self-closing-comp.md) | Disallow extra closing tags for components without children. |
+| ✔ | 🔧 | [solid/style-prop](docs/style-prop.md) | Require CSS properties in the `style` prop to be valid and kebab-cased (ex. 'font-size'), not camel-cased (ex. 'fontSize') like in React, and that property values with dimensions are strings, not numbers with implicit 'px' units. |
 <!-- AUTO-GENERATED-CONTENT:END -->
 
 ## Versioning
@@ -149,10 +147,8 @@ stable across patch (`0.0.x`) versions, but may change across minor (`0.x`) vers
 If you want to pin a minor version, use a tilde in your `package.json`.
 
 <!-- AUTO-GENERATED-CONTENT:START (TILDE) -->
-
 ```diff
 - "eslint-plugin-solid": "^0.7.4"
 + "eslint-plugin-solid": "~0.7.4"
 ```
-
 <!-- AUTO-GENERATED-CONTENT:END -->

--- a/docs/components-return-once.md
+++ b/docs/components-return-once.md
@@ -106,6 +106,13 @@ function Component(props) {
   return props.primary || <div>{props.secondaryText}</div>;
 }
  
+HOC(() => {
+  if (condition) {
+    return <div />;
+  }
+  return <div />;
+});
+ 
 ```
 
 ### Valid Examples
@@ -130,6 +137,13 @@ function notAComponent() {
   }
   return <div />;
 }
+
+callback(() => {
+  if (condition) {
+    return <div />;
+  }
+  return <div />;
+});
 
 ```
 <!-- AUTO-GENERATED-CONTENT:END -->

--- a/src/rules/components-return-once.ts
+++ b/src/rules/components-return-once.ts
@@ -62,7 +62,12 @@ const rule: TSESLint.RuleModule<"noEarlyReturn" | "noConditionalReturn", []> = {
     const onFunctionExit = (node: FunctionNode) => {
       if (
         (node.type === "FunctionDeclaration" && node.id?.name?.match(/^[a-z]/)) ||
-        node.parent?.type === "JSXExpressionContainer" // "render props" aren't components
+        // "render props" aren't components
+        node.parent?.type === "JSXExpressionContainer" ||
+        // ignore createMemo(() => conditional JSX), report HOC(() => conditional JSX)
+        (node.parent?.type === "CallExpression" &&
+          node.parent.arguments.some((n) => n === node) &&
+          !(node.parent.callee as T.Identifier).name?.match(/^[A-Z]/))
       ) {
         currentFunction().isComponent = false;
       }

--- a/test/rules/components-return-once.test.ts
+++ b/test/rules/components-return-once.test.ts
@@ -18,6 +18,12 @@ export const cases = run("components-return-once", rule, {
       }
       return <div />;
     }`,
+    `callback(() => {
+      if (condition) {
+        return <div />;
+      }
+      return <div />;
+    });`,
   ],
   invalid: [
     // Early returns
@@ -110,6 +116,16 @@ export const cases = run("components-return-once", rule, {
   return props.primary || <div>{props.secondaryText}</div>;
 }`,
       errors: [{ messageId: "noConditionalReturn" }],
+    },
+    // HOCs
+    {
+      code: `HOC(() => {
+        if (condition) {
+          return <div />;
+        }
+        return <div />;
+      });`,
+      errors: [{ messageId: "noEarlyReturn" }],
     },
   ],
 });


### PR DESCRIPTION
Re: [this message](https://discord.com/channels/722131463138705510/722131463889223772/1030930140693266512), some people are getting trouble with false positives from `solid/components-return-once` thinking `createMemo` functions are components.

This PR prevents the rule from considering callbacks from functions like `createMemo` as components. Specifically, that means functions starting with a lowercase letter; the minority of functions starting with an uppercase letter in Solid code are likely to be Higher-Order Components (HOCs) and callback functions there are still considered components.