### PR TITLE
Silence reactivity warnings in callback refs.

### DIFF
--- a/test/rules/reactivity.test.ts
+++ b/test/rules/reactivity.test.ts
@@ -216,6 +216,29 @@ export const cases = run("reactivity", rule, {
     // function expression inside tagged template literal expression is tracked scope
     "css`color: ${props => props.color}`;",
     "html`<div>${props => props.name}</div>`;",
+    // refs
+    `function Component() {
+      let canvas;
+      return <canvas ref={canvas} />;
+    }`,
+    `function Component() {
+      let canvas;
+      return (
+        <canvas ref={c => {
+          canvas = c;
+        }} />
+      );
+    }`,
+    `function Component() {
+      const [index] = createSignal(0);
+      let canvas;
+      return (
+        <canvas ref={c => {
+          index();
+          canvas = c;
+        }} />
+      );
+    }`,
   ],
   invalid: [
     // Untracked signals


### PR DESCRIPTION
Based on [this discussion](https://discord.com/channels/722131463138705510/723573901862371449/1045411393890955304) in the Solid Discord, we realized that using reactivity in callback refs was generating warnings, even though conceptually it's the same as using reactivity in event handlers (fine). This PR adds callback refs as `"called-function"` tracked scopes.