### PR TITLE
Fix onDblClick -> onDoubleClick, put spread event handler warning behind a flag

### DIFF
--- a/docs/event-handlers.md
+++ b/docs/event-handlers.md
@@ -19,6 +19,8 @@ Options shown here are the defaults.
   "solid/event-handlers": ["warn", { 
     // if true, don't warn on ambiguously named event handlers like `onclick` or `onchange`
     ignoreCase: false, 
+    // if true, warn when spreading event handlers onto JSX. Enable for Solid < v1.6.
+    warnOnSpread: false, 
   }]
 }
 ```
@@ -60,6 +62,39 @@ let el = <div onLy={"string"} />;
 const string = "string";
 let el = <div onLy={string} />;
  
+let el = <div onDoubleClick={() => {}} />;
+// after eslint --fix:
+let el = <div onDblClick={() => {}} />;
+ 
+let el = <div ondoubleclick={() => {}} />;
+// after eslint --fix:
+let el = <div onDblClick={() => {}} />;
+ 
+let el = <div ondblclick={() => {}} />;
+// after eslint --fix:
+let el = <div onDblClick={() => {}} />;
+ 
+/* eslint solid/event-handlers: ["error", { "warnOnSpread": true }] */
+const handleClick = () => 42;
+let el = <div {...{ onClick: handleClick, foo }} />;
+// after eslint --fix:
+const handleClick = () => 42;
+let el = <div {...{ foo }} onClick={handleClick} />;
+ 
+/* eslint solid/event-handlers: ["error", { "warnOnSpread": true }] */
+const handleClick = () => 42;
+let el = <div {...{ foo, onClick: handleClick }} />;
+// after eslint --fix:
+const handleClick = () => 42;
+let el = <div {...{ foo }} onClick={handleClick} />;
+ 
+/* eslint solid/event-handlers: ["error", { "warnOnSpread": true }] */
+const handleClick = () => 42;
+let el = <div {...{ onClick: handleClick }} />;
+// after eslint --fix:
+const handleClick = () => 42;
+let el = <div onClick={handleClick} />;
+ 
 ```
 
 ### Valid Examples
@@ -88,6 +123,11 @@ let el = <div onLy={() => {}} />;
 let el = <div on:ly={() => {}} />;
 
 let el = <foo.bar only="true" />;
+
+let el = <div onDblClick={() => {}} />;
+
+const onClick = () => 42;
+let el = <div {...{ onClick }} />;
 
 /* eslint solid/event-handlers: ["error", { "ignoreCase": true }] */
 let el = <div onclick={onclick} />;

--- a/test/rules/event-handlers.test.ts
+++ b/test/rules/event-handlers.test.ts
@@ -18,6 +18,9 @@ export const cases = run("event-handlers", rule, {
     `let el = <div onLy={() => {}} />;`,
     `let el = <div on:ly={() => {}} />;`,
     `let el = <foo.bar only="true" />;`,
+    `let el = <div onDblClick={() => {}} />;`,
+    `const onClick = () => 42;
+    let el = <div {...{ onClick }} />;`,
     { code: `let el = <div onclick={onclick} />`, options: [{ ignoreCase: true }] },
     { code: `let el = <div only={only} />`, options: [{ ignoreCase: true }] },
   ],
@@ -119,6 +122,51 @@ export const cases = run("event-handlers", rule, {
           type: T.JSXAttribute,
         },
       ],
+    },
+    {
+      code: `let el = <div onDoubleClick={() => {}} />;`,
+      errors: [
+        { messageId: "nonstandard", data: { name: "onDoubleClick", fixedName: "onDblClick" } },
+      ],
+      output: `let el = <div onDblClick={() => {}} />;`,
+    },
+    {
+      code: `let el = <div ondoubleclick={() => {}} />;`,
+      errors: [
+        { messageId: "nonstandard", data: { name: "ondoubleclick", fixedName: "onDblClick" } },
+      ],
+      output: `let el = <div onDblClick={() => {}} />;`,
+    },
+    {
+      code: `let el = <div ondblclick={() => {}} />;`,
+      errors: [
+        { messageId: "capitalization", data: { name: "ondblclick", fixedName: "onDblClick" } },
+      ],
+      output: `let el = <div onDblClick={() => {}} />;`,
+    },
+    {
+      code: `const handleClick = () => 42;
+      let el = <div {...{ onClick: handleClick, foo }} />;`,
+      options: [{ warnOnSpread: true }],
+      errors: [{ messageId: "spread-handler", data: { name: "onClick" } }],
+      output: `const handleClick = () => 42;
+      let el = <div {...{  foo }} onClick={handleClick} />;`,
+    },
+    {
+      code: `const handleClick = () => 42;
+      let el = <div {...{ foo, onClick: handleClick, }} />;`,
+      options: [{ warnOnSpread: true }],
+      errors: [{ messageId: "spread-handler", data: { name: "onClick" } }],
+      output: `const handleClick = () => 42;
+      let el = <div {...{ foo,  }} onClick={handleClick} />;`,
+    },
+    {
+      code: `const handleClick = () => 42;
+      let el = <div {...{ onClick: handleClick }} />;`,
+      options: [{ warnOnSpread: true }],
+      errors: [{ messageId: "spread-handler", data: { name: "onClick" } }],
+      output: `const handleClick = () => 42;
+      let el = <div  onClick={handleClick} />;`,
     },
   ],
 });


### PR DESCRIPTION
Closes #46. I inadvertently enforced React's special double click event instead of the standard `dblclick` event. This PR makes that no longer a warning and automatically corrects `onDoubleClick` back to `onDblClick`.

With Solid's improvements to JSX spreading in v1.6, there's now no need to warn when spreading an event handler into JSX, at least one that's statically analyzable. The part of the `solid/event-handlers` rule that warned on this is now behind an option, `warnOnSpread`.