### PR TITLE
Recognise mapArray as a tracked scope

### DIFF
--- a/docs/reactivity.md
+++ b/docs/reactivity.md
@@ -227,6 +227,16 @@ css`
   color: ${f};
 `;
  
+function createCustomStore() {
+  const [store, updateStore] = createStore({});
+
+  return mapArray(
+    [],
+    // the second argument to mapArray is not tracked
+    (item) => store.path.to.field
+  );
+}
+ 
 ```
 
 ### Valid Examples
@@ -505,6 +515,16 @@ function Component() {
         canvas = c;
       }}
     />
+  );
+}
+
+function createCustomStore() {
+  const [store, updateStore] = createStore({});
+
+  return mapArray(
+    // the first argument to mapArray is a tracked scope
+    () => store.path.to.field,
+    (item) => ({})
   );
 }
 

--- a/src/rules/reactivity.ts
+++ b/src/rules/reactivity.ts
@@ -813,6 +813,7 @@ const rule: TSESLint.RuleModule<MessageIds, []> = {
               "createComputed",
               "createSelector",
               "untrack",
+              "mapArray",
             ],
             callee.name
           ) ||

--- a/test/rules/reactivity.test.ts
+++ b/test/rules/reactivity.test.ts
@@ -223,6 +223,16 @@ export const cases = run("reactivity", rule, {
         }} />
       );
     }`,
+    // mapArray()
+    `function createCustomStore() {
+      const [store, updateStore] = createStore({});
+
+      return mapArray(
+        // the first argument to mapArray is a tracked scope
+        () => store.path.to.field,
+        (item) => ({})
+      );
+    }`,
   ],
   invalid: [
     // Untracked signals
@@ -645,6 +655,20 @@ export const cases = run("reactivity", rule, {
       const f = () => signal();
       css\`color: \${f}\`;`,
       errors: [{ messageId: "badSignal", line: 4 }],
+    },
+    // mapArray
+    {
+      code: `
+      function createCustomStore() {
+        const [store, updateStore] = createStore({});
+
+        return mapArray(
+          [],
+          // the second argument to mapArray is not tracked
+          (item) => store.path.to.field
+        );
+      }`,
+      errors: [{ messageId: "badUnnamedDerivedSignal", line: 7 }],
     },
   ],
 });


### PR DESCRIPTION
Previously, `mapArray` was not seen as a tracked scope.  Now, the first argument to `mapArray` is seen as a tracked scope, but the second argument is not.

See #52 and #55 for details.

Fixes #55 