### PR TITLE
Treat type casts and assertions as transparent in reactivity analysis.

### DIFF
--- a/scripts/docs.ts
+++ b/scripts/docs.ts
@@ -104,7 +104,7 @@ const buildOptions = (filename: string): string => {
   ].join("\n");
 };
 
-const pretty = (code: string) => prettier.format(code, { parser: "babel" }).trim();
+const pretty = (code: string) => prettier.format(code, { parser: "typescript" }).trim();
 const options = (options: Array<any>) =>
   options
     .map((o) =>

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -69,6 +69,17 @@ export function trace(node: T.Node, initialScope: TSESLint.Scope.Scope): T.Node 
   return node;
 }
 
+/** Get the relevant node when wrapped by a node that doesn't change the behavior */
+export function ignoreTransparentWrappers(node: T.Node, up = false): T.Node {
+  if (node.type === "TSAsExpression" || node.type === "TSNonNullExpression") {
+    const next = up ? node.parent : node.expression;
+    if (next) {
+      return ignoreTransparentWrappers(next, up);
+    }
+  }
+  return node;
+}
+
 export type FunctionNode = T.FunctionExpression | T.ArrowFunctionExpression | T.FunctionDeclaration;
 const FUNCTION_TYPES = ["FunctionExpression", "ArrowFunctionExpression", "FunctionDeclaration"];
 export const isFunctionNode = (node: T.Node | null | undefined): node is FunctionNode =>

--- a/test/rules/reactivity.test.ts
+++ b/test/rules/reactivity.test.ts
@@ -1,5 +1,5 @@
 import { AST_NODE_TYPES as T } from "@typescript-eslint/utils";
-import { run } from "../ruleTester";
+import { run, tsOnlyTest } from "../ruleTester";
 import rule from "../../src/rules/reactivity";
 
 export const cases = run("reactivity", rule, {
@@ -251,6 +251,19 @@ export const cases = run("reactivity", rule, {
         (item) => ({})
       );
     }`,
+    // type casting
+    {
+      code: `const m = createMemo(() => 5) as Accessor<number>;`,
+      ...tsOnlyTest,
+    },
+    {
+      code: `const m = createMemo(() => 5)!;`,
+      ...tsOnlyTest,
+    },
+    {
+      code: `const m = createMemo(() => 5)! as Accessor<number>;`,
+      ...tsOnlyTest,
+    },
   ],
   invalid: [
     // Untracked signals


### PR DESCRIPTION
Closes #60. Handles passing through TS type casts and non-null assertions when figuring out which variables are reactive. There might still be an edge case or two but I'll keep this in mind as reactivity analysis is cleaned up.