### PR TITLE
Mark props by name on enter pass instead of exit.

### DIFF
--- a/docs/reactivity.md
+++ b/docs/reactivity.md
@@ -48,6 +48,12 @@ const Component = (props) => {
   return <div>{value()}</div>;
 };
  
+const Component = (props) => {
+  const derived = () => props.value;
+  const oops = derived();
+  return <div>{oops}</div>;
+};
+ 
 function Component(something) {
   console.log(something.a);
   return <div />;

--- a/test/rules/reactivity.test.ts
+++ b/test/rules/reactivity.test.ts
@@ -320,6 +320,22 @@ export const cases = run("reactivity", rule, {
         },
       ],
     },
+    // mark `props` as props by name before we've determined if Component is a component in :exit
+    {
+      code: `
+      const Component = props => {
+        const derived = () => props.value;
+        const oops = derived();
+        return <div>{oops}</div>;
+      }`,
+      errors: [
+        {
+          messageId: "untrackedReactive",
+          data: { name: "derived" },
+          type: T.CallExpression,
+        },
+      ],
+    },
     // treat first parameter of uppercase function with JSX as a props
     {
       code: `


### PR DESCRIPTION
Closes #61. Previously `props` were marked as reactive on exit pass, so it wouldn't be caught in deeper scopes as they would have finished analysis before the variable was marked. Now, if the props match `isPropsByName`, they'll be marked on the entry pass; otherwise, behavior is unchanged.