### PR TITLE
Allow using 'static*' props outside tracked scopes, but forbid passing reactive variables to them in the caller

### DIFF
--- a/docs/reactivity.md
+++ b/docs/reactivity.md
@@ -387,6 +387,9 @@ const result = indexArray(array, (item) => {
   item();
 });
  
+const [signal] = createSignal();
+let el = <Component staticProp={signal()} />;
+ 
 ```
 
 ### Valid Examples
@@ -717,6 +720,15 @@ function Component(props) {
       }}
     </div>
   );
+}
+
+function Component(props) {
+  const value = props.staticValue;
+}
+
+function Component() {
+  const staticValue = () => props.value;
+  const value = staticValue();
 }
 
 ```

--- a/src/rules/reactivity.ts
+++ b/src/rules/reactivity.ts
@@ -547,7 +547,7 @@ const rule: TSESLint.RuleModule<MessageIds, []> = {
             });
           } else if (
             parent.property.type === "Identifier" &&
-            /^(?:initial|default)[A-Z]/.test(parent.property.name)
+            /^(?:initial|default|static)[A-Z]/.test(parent.property.name)
           ) {
             // We're using a prop with a name that starts with `initial` or
             // `default`, like `props.initialCount`. We'll refrain from warning
@@ -831,6 +831,18 @@ const rule: TSESLint.RuleModule<MessageIds, []> = {
           // rule will warn later.
           // TODO: add some kind of "anti- tracked scope" that still warns but enhances the error
           // message if matched.
+        } else if (
+          node.parent?.type === "JSXAttribute" &&
+          node.parent.name?.type === "JSXIdentifier" &&
+          /^static[A-Z]/.test(node.parent.name.name) &&
+          node.parent.parent?.type === "JSXOpeningElement" &&
+          node.parent.parent.name.type === "JSXIdentifier" &&
+          !isDOMElementName(node.parent.parent.name.name)
+        ) {
+          // A caller is passing a value to a prop prefixed with `static` in a component, i.e.
+          // `<Box staticName={...} />`. Since we're considering these props as static in the component
+          // we shouldn't allow passing reactive values to them, as this isn't just ignoring reactivity
+          // like initial*/default*; this is disabling it altogether as a convention. Do nothing.
         } else if (
           node.parent?.type === "JSXAttribute" &&
           node.parent.name.name === "ref" &&

--- a/test/rules/reactivity.test.ts
+++ b/test/rules/reactivity.test.ts
@@ -273,6 +273,14 @@ export const cases = run("reactivity", rule, {
         }}</div>
       );
     }`,
+    // static* prefix for props
+    `function Component(props) {
+      const value = props.staticValue;
+    }`,
+    `function Component() {
+      const staticValue = () => props.value;
+      const value = staticValue();
+    }`,
   ],
   invalid: [
     // Untracked signals
@@ -739,6 +747,13 @@ export const cases = run("reactivity", rule, {
         item()
       });`,
       errors: [{ messageId: "untrackedReactive", line: 4 }],
+    },
+    // static* prefix for props
+    {
+      code: `
+      const [signal] = createSignal();
+      let el = <Component staticProp={signal()} />;`,
+      errors: [{ messageId: "untrackedReactive" }],
     },
   ],
 });


### PR DESCRIPTION
Closes #78.

There's been some desire in the community to treat some props as "static", i.e. constant over the lifetime of the component, so that they can be assigned at the top level of the component without getting flak from the linter. 

**I don't recommend this pattern**. Though it might save a few keystrokes and potentially an <sub>infinitesimal</sub> amount of performance over regular access/memoization, it's more idiomatic and maintainable to treat all props as if they could potentially change. Whether a prop will or won't change is not defined near the component code; you or a future collaborator could pass a reactive variable to a "static" prop a long time from now without knowing about the potential issue, and it's easy to run into bugs.

_However,_ if people are going to do this, then the tooling should provide as much safety as it can. So:

1. To define a prop as "static", prefix it with `static` when accessing it.

  ```jsx
  function Component(props) {
    const name = props.staticName;
    // ...
  }
  ```

2. When providing a "static" prop, don't pass a reactive variable; the linter will warn if you do.

  ```jsx
  const [name, setName] = createSignal("Alice");

  return <Component staticName={name()} />; // The reactive variable 'name()' should be used within JSX [...] or else changes will be ignored.
  return <Component staticName="Alice" />; // ok
  ```