### PR TITLE
Fixes regression where functions could not be passed inline to component event handlers

### DIFF
--- a/docs/reactivity.md
+++ b/docs/reactivity.md
@@ -620,8 +620,16 @@ function Component() {
   return <div on:click={() => console.log(signal())} />;
 }
 
+function Component(props) {
+  return <div onClick={(e) => props.onClick(e)} />;
+}
+
 const Parent = (props) => {
   return <Child onClick={props.onClick} />;
+};
+
+const Parent = (props) => {
+  return <Child onClick={(e) => props.onClick(e)} />;
 };
 
 const Component = (props) => {
@@ -741,6 +749,9 @@ function Component(props) {
     </div>
   );
 }
+
+const [signal, setSignal] = createSignal();
+let el = <Child foo={() => signal()}></Child>;
 
 function Component(props) {
   const value = props.staticValue;

--- a/src/rules/reactivity.ts
+++ b/src/rules/reactivity.ts
@@ -568,16 +568,14 @@ export default createRule({
       }
 
       // If there are any unnamed derived signals, they must match a tracked
-      // scope exactly. Usually anonymous arrow function args to createEffect,
+      // scope. Usually anonymous arrow function args to createEffect,
       // createMemo, etc.
       const { unnamedDerivedSignals } = currentScope();
       if (unnamedDerivedSignals) {
         for (const node of unnamedDerivedSignals) {
           if (
-            !currentScope().trackedScopes.find(
-              (trackedScope) =>
-                trackedScope.node === node &&
-                (trackedScope.expect === "function" || trackedScope.expect === "called-function")
+            !currentScope().trackedScopes.find((trackedScope) =>
+              matchTrackedScope(trackedScope, node)
             )
           ) {
             context.report({

--- a/test/rules/reactivity.test.ts
+++ b/test/rules/reactivity.test.ts
@@ -177,9 +177,15 @@ export const cases = run("reactivity", rule, {
       const [signal, setSignal] = createSignal(1);
       return <div on:click={() => console.log(signal())} />;
     }`,
+    `function Component(props) {
+      return <div onClick={e => props.onClick(e)} />;
+    }`,
     // event listeners are reactive on components
     `const Parent = props => {
       return <Child onClick={props.onClick} />;
+    }`,
+    `const Parent = props => {
+      return <Child onClick={e => props.onClick(e)} />;
     }`,
     // Pass reactive variables as-is into provider value prop
     `const Component = props => {
@@ -289,6 +295,9 @@ export const cases = run("reactivity", rule, {
         }}</div>
       );
     }`,
+    // passing function instead of signal
+    `const [signal, setSignal] = createSignal();
+    let el = <Child foo={() => signal()}></Child>`,
     // static* prefix for props
     `function Component(props) {
       const value = props.staticValue;


### PR DESCRIPTION
Code like `<Comp onClick={() => props.onClick}>` was failing, because of the extra specificity that anonymous functions receive when matching against tracked scopes. This PR simply removes the special treatment and uses the normal tracked scope matching function, which allows tracked scopes marked as expressions.

Component event handlers are now marked as expressions, like other props, because they do rebind. They were previously mistakenly marked as accepting functions only, like native element event handlers.