### PR TITLE
Fix minor syntax mistake in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ For TypeScript:
 ```js
 import js from "@eslint/js";
 import solid from 'eslint-plugin-solid/configs/typescript';
-import * as tsParser from "@typescript-eslint/parser",
+import * as tsParser from "@typescript-eslint/parser";
 
 export default [
   js.configs.recommended,


### PR DESCRIPTION
On line 3 of the flat eslint config example for typescript, a colon is used instead of a semicolon. This PR fixes that.