### PR TITLE
Enable type generation

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "@rollup/plugin-commonjs": "^22.0.2",
     "@rollup/plugin-json": "^4.1.0",
     "@rollup/plugin-node-resolve": "^14.1.0",
-    "@tsconfig/node16": "^16.1.0",
+    "@tsconfig/node20": "^20.1.2",
     "@types/eslint": "^8.40.2",
     "@types/estraverse": "^5.1.7",
     "@types/fs-extra": "^9.0.13",
@@ -80,7 +80,7 @@
     "rollup": "^2.79.1",
     "ts-jest": "^29.1.1",
     "ts-node": "^10.9.1",
-    "typescript": "^5.1.6"
+    "typescript": "^5.4.2"
   },
   "peerDependencies": {
     "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,7 +7,7 @@ settings:
 dependencies:
   '@typescript-eslint/utils':
     specifier: ^6.4.0
-    version: 6.4.0(eslint@8.43.0)(typescript@5.1.6)
+    version: 6.4.0(eslint@8.43.0)(typescript@5.4.2)
   estraverse:
     specifier: ^5.3.0
     version: 5.3.0
@@ -43,9 +43,9 @@ devDependencies:
   '@rollup/plugin-node-resolve':
     specifier: ^14.1.0
     version: 14.1.0(rollup@2.79.1)
-  '@tsconfig/node16':
-    specifier: ^16.1.0
-    version: 16.1.0
+  '@tsconfig/node20':
+    specifier: ^20.1.2
+    version: 20.1.2
   '@types/eslint':
     specifier: ^8.40.2
     version: 8.40.2
@@ -72,10 +72,10 @@ devDependencies:
     version: 2.7.2
   '@typescript-eslint/eslint-plugin':
     specifier: ^6.4.0
-    version: 6.4.0(@typescript-eslint/parser@6.4.0)(eslint@8.43.0)(typescript@5.1.6)
+    version: 6.4.0(@typescript-eslint/parser@6.4.0)(eslint@8.43.0)(typescript@5.4.2)
   '@typescript-eslint/parser':
     specifier: ^6.4.0
-    version: 6.4.0(eslint@8.43.0)(typescript@5.1.6)
+    version: 6.4.0(eslint@8.43.0)(typescript@5.4.2)
   eslint:
     specifier: ^8.43.0
     version: 8.43.0
@@ -126,13 +126,13 @@ devDependencies:
     version: 2.79.1
   ts-jest:
     specifier: ^29.1.1
-    version: 29.1.1(@babel/core@7.21.3)(jest@29.5.0)(typescript@5.1.6)
+    version: 29.1.1(@babel/core@7.21.3)(jest@29.5.0)(typescript@5.4.2)
   ts-node:
     specifier: ^10.9.1
-    version: 10.9.1(@types/node@16.18.16)(typescript@5.1.6)
+    version: 10.9.1(@types/node@16.18.16)(typescript@5.4.2)
   typescript:
-    specifier: ^5.1.6
-    version: 5.1.6
+    specifier: ^5.4.2
+    version: 5.4.2
 
 packages:
 
@@ -1119,12 +1119,12 @@ packages:
     resolution: {integrity: sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==}
     dev: true
 
-  /@tsconfig/node16@1.0.3:
-    resolution: {integrity: sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ==}
+  /@tsconfig/node16@1.0.4:
+    resolution: {integrity: sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==}
     dev: true
 
-  /@tsconfig/node16@16.1.0:
-    resolution: {integrity: sha512-cfwhqrdZEKS+Iqu1OPDwmKsOV/eo7q4sPhWzOXc1rU77nnPFV3+77yPg8uKQ2e8eir6mERCvrKnd+EGa4qo4bQ==}
+  /@tsconfig/node20@20.1.2:
+    resolution: {integrity: sha512-madaWq2k+LYMEhmcp0fs+OGaLFk0OenpHa4gmI4VEmCKX4PJntQ6fnnGADVFrVkBj0wIdAlQnK/MrlYTHsa1gQ==}
     dev: true
 
   /@types/babel__core@7.20.0:
@@ -1311,7 +1311,7 @@ packages:
       '@types/yargs-parser': 21.0.0
     dev: true
 
-  /@typescript-eslint/eslint-plugin@6.4.0(@typescript-eslint/parser@6.4.0)(eslint@8.43.0)(typescript@5.1.6):
+  /@typescript-eslint/eslint-plugin@6.4.0(@typescript-eslint/parser@6.4.0)(eslint@8.43.0)(typescript@5.4.2):
     resolution: {integrity: sha512-62o2Hmc7Gs3p8SLfbXcipjWAa6qk2wZGChXG2JbBtYpwSRmti/9KHLqfbLs9uDigOexG+3PaQ9G2g3201FWLKg==}
     engines: {node: ^16.0.0 || >=18.0.0}
     peerDependencies:
@@ -1323,10 +1323,10 @@ packages:
         optional: true
     dependencies:
       '@eslint-community/regexpp': 4.6.2
-      '@typescript-eslint/parser': 6.4.0(eslint@8.43.0)(typescript@5.1.6)
+      '@typescript-eslint/parser': 6.4.0(eslint@8.43.0)(typescript@5.4.2)
       '@typescript-eslint/scope-manager': 6.4.0
-      '@typescript-eslint/type-utils': 6.4.0(eslint@8.43.0)(typescript@5.1.6)
-      '@typescript-eslint/utils': 6.4.0(eslint@8.43.0)(typescript@5.1.6)
+      '@typescript-eslint/type-utils': 6.4.0(eslint@8.43.0)(typescript@5.4.2)
+      '@typescript-eslint/utils': 6.4.0(eslint@8.43.0)(typescript@5.4.2)
       '@typescript-eslint/visitor-keys': 6.4.0
       debug: 4.3.4(supports-color@8.1.1)
       eslint: 8.43.0
@@ -1334,13 +1334,13 @@ packages:
       ignore: 5.2.4
       natural-compare: 1.4.0
       semver: 7.5.4
-      ts-api-utils: 1.0.2(typescript@5.1.6)
-      typescript: 5.1.6
+      ts-api-utils: 1.0.2(typescript@5.4.2)
+      typescript: 5.4.2
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@typescript-eslint/parser@6.4.0(eslint@8.43.0)(typescript@5.1.6):
+  /@typescript-eslint/parser@6.4.0(eslint@8.43.0)(typescript@5.4.2):
     resolution: {integrity: sha512-I1Ah1irl033uxjxO9Xql7+biL3YD7w9IU8zF+xlzD/YxY6a4b7DYA08PXUUCbm2sEljwJF6ERFy2kTGAGcNilg==}
     engines: {node: ^16.0.0 || >=18.0.0}
     peerDependencies:
@@ -1352,11 +1352,11 @@ packages:
     dependencies:
       '@typescript-eslint/scope-manager': 6.4.0
       '@typescript-eslint/types': 6.4.0
-      '@typescript-eslint/typescript-estree': 6.4.0(typescript@5.1.6)
+      '@typescript-eslint/typescript-estree': 6.4.0(typescript@5.4.2)
       '@typescript-eslint/visitor-keys': 6.4.0
       debug: 4.3.4(supports-color@8.1.1)
       eslint: 8.43.0
-      typescript: 5.1.6
+      typescript: 5.4.2
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -1368,7 +1368,7 @@ packages:
       '@typescript-eslint/types': 6.4.0
       '@typescript-eslint/visitor-keys': 6.4.0
 
-  /@typescript-eslint/type-utils@6.4.0(eslint@8.43.0)(typescript@5.1.6):
+  /@typescript-eslint/type-utils@6.4.0(eslint@8.43.0)(typescript@5.4.2):
     resolution: {integrity: sha512-TvqrUFFyGY0cX3WgDHcdl2/mMCWCDv/0thTtx/ODMY1QhEiyFtv/OlLaNIiYLwRpAxAtOLOY9SUf1H3Q3dlwAg==}
     engines: {node: ^16.0.0 || >=18.0.0}
     peerDependencies:
@@ -1378,12 +1378,12 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/typescript-estree': 6.4.0(typescript@5.1.6)
-      '@typescript-eslint/utils': 6.4.0(eslint@8.43.0)(typescript@5.1.6)
+      '@typescript-eslint/typescript-estree': 6.4.0(typescript@5.4.2)
+      '@typescript-eslint/utils': 6.4.0(eslint@8.43.0)(typescript@5.4.2)
       debug: 4.3.4(supports-color@8.1.1)
       eslint: 8.43.0
-      ts-api-utils: 1.0.2(typescript@5.1.6)
-      typescript: 5.1.6
+      ts-api-utils: 1.0.2(typescript@5.4.2)
+      typescript: 5.4.2
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -1392,7 +1392,7 @@ packages:
     resolution: {integrity: sha512-+FV9kVFrS7w78YtzkIsNSoYsnOtrYVnKWSTVXoL1761CsCRv5wpDOINgsXpxD67YCLZtVQekDDyaxfjVWUJmmg==}
     engines: {node: ^16.0.0 || >=18.0.0}
 
-  /@typescript-eslint/typescript-estree@6.4.0(typescript@5.1.6):
+  /@typescript-eslint/typescript-estree@6.4.0(typescript@5.4.2):
     resolution: {integrity: sha512-iDPJArf/K2sxvjOR6skeUCNgHR/tCQXBsa+ee1/clRKr3olZjZ/dSkXPZjG6YkPtnW6p5D1egeEPMCW6Gn4yLA==}
     engines: {node: ^16.0.0 || >=18.0.0}
     peerDependencies:
@@ -1407,12 +1407,12 @@ packages:
       globby: 11.1.0
       is-glob: 4.0.3
       semver: 7.5.4
-      ts-api-utils: 1.0.2(typescript@5.1.6)
-      typescript: 5.1.6
+      ts-api-utils: 1.0.2(typescript@5.4.2)
+      typescript: 5.4.2
     transitivePeerDependencies:
       - supports-color
 
-  /@typescript-eslint/utils@6.4.0(eslint@8.43.0)(typescript@5.1.6):
+  /@typescript-eslint/utils@6.4.0(eslint@8.43.0)(typescript@5.4.2):
     resolution: {integrity: sha512-BvvwryBQpECPGo8PwF/y/q+yacg8Hn/2XS+DqL/oRsOPK+RPt29h5Ui5dqOKHDlbXrAeHUTnyG3wZA0KTDxRZw==}
     engines: {node: ^16.0.0 || >=18.0.0}
     peerDependencies:
@@ -1423,7 +1423,7 @@ packages:
       '@types/semver': 7.5.0
       '@typescript-eslint/scope-manager': 6.4.0
       '@typescript-eslint/types': 6.4.0
-      '@typescript-eslint/typescript-estree': 6.4.0(typescript@5.1.6)
+      '@typescript-eslint/typescript-estree': 6.4.0(typescript@5.4.2)
       eslint: 8.43.0
       semver: 7.5.4
     transitivePeerDependencies:
@@ -2248,7 +2248,7 @@ packages:
       eslint-import-resolver-webpack:
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 6.4.0(eslint@8.43.0)(typescript@5.1.6)
+      '@typescript-eslint/parser': 6.4.0(eslint@8.43.0)(typescript@5.4.2)
       debug: 3.2.7
       eslint: 8.43.0
       eslint-import-resolver-node: 0.3.7
@@ -2277,7 +2277,7 @@ packages:
       '@typescript-eslint/parser':
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 6.4.0(eslint@8.43.0)(typescript@5.1.6)
+      '@typescript-eslint/parser': 6.4.0(eslint@8.43.0)(typescript@5.4.2)
       array-includes: 3.1.6
       array.prototype.flat: 1.3.1
       array.prototype.flatmap: 1.3.1
@@ -2739,8 +2739,8 @@ packages:
   /fs.realpath@1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
 
-  /fsevents@2.3.2:
-    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+  /fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
     requiresBuild: true
@@ -3432,7 +3432,7 @@ packages:
       pretty-format: 29.5.0
       slash: 3.0.0
       strip-json-comments: 3.1.1
-      ts-node: 10.9.1(@types/node@16.18.16)(typescript@5.1.6)
+      ts-node: 10.9.1(@types/node@16.18.16)(typescript@5.4.2)
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -3513,7 +3513,7 @@ packages:
       micromatch: 4.0.5
       walker: 1.0.8
     optionalDependencies:
-      fsevents: 2.3.2
+      fsevents: 2.3.3
     dev: true
 
   /jest-leak-detector@29.5.0:
@@ -4682,7 +4682,7 @@ packages:
     resolution: {integrity: sha512-uKxbd0IhMZOhjAiD5oAFp7BqvkA4Dv47qpOCtaNvng4HBwdbWtdOh8f5nZNuk2rp51PMGk3bzfWu5oayNEuYnw==}
     engines: {node: '>=10.0.0'}
     optionalDependencies:
-      fsevents: 2.3.2
+      fsevents: 2.3.3
     dev: true
 
   /run-async@2.4.1:
@@ -5084,15 +5084,15 @@ packages:
     resolution: {integrity: sha512-rvuRbTarPXmMb79SmzEp8aqXNKcK+y0XaB298IXueQ8I2PsrATcPBCSPyK/dDNa2iWOhKlfNnOjdAOTBU/nkFA==}
     dev: true
 
-  /ts-api-utils@1.0.2(typescript@5.1.6):
+  /ts-api-utils@1.0.2(typescript@5.4.2):
     resolution: {integrity: sha512-Cbu4nIqnEdd+THNEsBdkolnOXhg0I8XteoHaEKgvsxpsbWda4IsUut2c187HxywQCvveojow0Dgw/amxtSKVkQ==}
     engines: {node: '>=16.13.0'}
     peerDependencies:
       typescript: '>=4.2.0'
     dependencies:
-      typescript: 5.1.6
+      typescript: 5.4.2
 
-  /ts-jest@29.1.1(@babel/core@7.21.3)(jest@29.5.0)(typescript@5.1.6):
+  /ts-jest@29.1.1(@babel/core@7.21.3)(jest@29.5.0)(typescript@5.4.2):
     resolution: {integrity: sha512-D6xjnnbP17cC85nliwGiL+tpoKN0StpgE0TeOjXQTU6MVCfsB4v7aW05CgQ/1OywGb0x/oy9hHFnN+sczTiRaA==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     hasBin: true
@@ -5122,11 +5122,11 @@ packages:
       lodash.memoize: 4.1.2
       make-error: 1.3.6
       semver: 7.5.3
-      typescript: 5.1.6
+      typescript: 5.4.2
       yargs-parser: 21.1.1
     dev: true
 
-  /ts-node@10.9.1(@types/node@16.18.16)(typescript@5.1.6):
+  /ts-node@10.9.1(@types/node@16.18.16)(typescript@5.4.2):
     resolution: {integrity: sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==}
     hasBin: true
     peerDependencies:
@@ -5144,7 +5144,7 @@ packages:
       '@tsconfig/node10': 1.0.9
       '@tsconfig/node12': 1.0.11
       '@tsconfig/node14': 1.0.3
-      '@tsconfig/node16': 1.0.3
+      '@tsconfig/node16': 1.0.4
       '@types/node': 16.18.16
       acorn: 8.8.2
       acorn-walk: 8.2.0
@@ -5152,7 +5152,7 @@ packages:
       create-require: 1.1.1
       diff: 4.0.2
       make-error: 1.3.6
-      typescript: 5.1.6
+      typescript: 5.4.2
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
     dev: true
@@ -5218,8 +5218,8 @@ packages:
     resolution: {integrity: sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==}
     dev: true
 
-  /typescript@5.1.6:
-    resolution: {integrity: sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==}
+  /typescript@5.4.2:
+    resolution: {integrity: sha512-+2/g0Fds1ERlP6JsakQQDXjZdZMM+rqpamFZJEKh4kwTIn3iDkgKtby0CeNd5ATNZ4Ry1ax15TMx0W2V+miizQ==}
     engines: {node: '>=14.17'}
     hasBin: true
 

--- a/src/configs/recommended.ts
+++ b/src/configs/recommended.ts
@@ -1,3 +1,11 @@
+/**
+ * FIXME: remove this comments and import when below issue is fixed.
+ * This import is necessary for type generation due to a bug in the TypeScript compiler.
+ * See: https://github.com/microsoft/TypeScript/issues/42873
+ */
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+import type { TSESLint } from "@typescript-eslint/utils";
+
 import { plugin } from "../plugin";
 
 const recommended = {

--- a/src/configs/typescript.ts
+++ b/src/configs/typescript.ts
@@ -1,3 +1,11 @@
+/**
+ * FIXME: remove this comments and import when below issue is fixed.
+ * This import is necessary for type generation due to a bug in the TypeScript compiler.
+ * See: https://github.com/microsoft/TypeScript/issues/42873
+ */
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+import type { TSESLint } from "@typescript-eslint/utils";
+
 import recommended from "./recommended";
 
 const typescript = {

--- a/src/index.ts
+++ b/src/index.ts
@@ -35,5 +35,6 @@ const pluginLegacy = {
     },
   },
 };
-// Must be module.exports for eslint to load everything
-module.exports = pluginLegacy;
+
+// Must be `export = ` for eslint to load everything
+export = pluginLegacy;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,11 @@
+/**
+ * FIXME: remove this comments and import when below issue is fixed.
+ * This import is necessary for type generation due to a bug in the TypeScript compiler.
+ * See: https://github.com/microsoft/TypeScript/issues/42873
+ */
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+import type { TSESLint } from "@typescript-eslint/utils";
+
 import { plugin } from "./plugin";
 import recommendedConfig from "./configs/recommended";
 import typescriptConfig from "./configs/typescript";

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -1,3 +1,11 @@
+/**
+ * FIXME: remove this comments and import when below issue is fixed.
+ * This import is necessary for type generation due to a bug in the TypeScript compiler.
+ * See: https://github.com/microsoft/TypeScript/issues/42873
+ */
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+import type { TSESLint } from "@typescript-eslint/utils";
+
 import componentsReturnOnce from "./rules/components-return-once";
 import eventHandlers from "./rules/event-handlers";
 import imports from "./rules/imports";

--- a/src/rules/components-return-once.ts
+++ b/src/rules/components-return-once.ts
@@ -1,3 +1,11 @@
+/**
+ * FIXME: remove this comments and import when below issue is fixed.
+ * This import is necessary for type generation due to a bug in the TypeScript compiler.
+ * See: https://github.com/microsoft/TypeScript/issues/42873
+ */
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+import type { TSESLint } from "@typescript-eslint/utils";
+
 import { TSESTree as T, ESLintUtils } from "@typescript-eslint/utils";
 import { getFunctionName, type FunctionNode } from "../utils";
 

--- a/src/rules/event-handlers.ts
+++ b/src/rules/event-handlers.ts
@@ -1,3 +1,11 @@
+/**
+ * FIXME: remove this comments and import when below issue is fixed.
+ * This import is necessary for type generation due to a bug in the TypeScript compiler.
+ * See: https://github.com/microsoft/TypeScript/issues/42873
+ */
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+import type { TSESLint } from "@typescript-eslint/utils";
+
 import { TSESTree as T, ESLintUtils, ASTUtils } from "@typescript-eslint/utils";
 import { isDOMElementName } from "../utils";
 

--- a/src/rules/jsx-no-duplicate-props.ts
+++ b/src/rules/jsx-no-duplicate-props.ts
@@ -1,3 +1,11 @@
+/**
+ * FIXME: remove this comments and import when below issue is fixed.
+ * This import is necessary for type generation due to a bug in the TypeScript compiler.
+ * See: https://github.com/microsoft/TypeScript/issues/42873
+ */
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+import type { TSESLint } from "@typescript-eslint/utils";
+
 import { TSESTree as T, ESLintUtils } from "@typescript-eslint/utils";
 import { jsxGetAllProps } from "../utils";
 

--- a/src/rules/jsx-no-script-url.ts
+++ b/src/rules/jsx-no-script-url.ts
@@ -1,3 +1,11 @@
+/**
+ * FIXME: remove this comments and import when below issue is fixed.
+ * This import is necessary for type generation due to a bug in the TypeScript compiler.
+ * See: https://github.com/microsoft/TypeScript/issues/42873
+ */
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+import type { TSESLint } from "@typescript-eslint/utils";
+
 import { ESLintUtils, ASTUtils } from "@typescript-eslint/utils";
 
 const createRule = ESLintUtils.RuleCreator.withoutDocs;

--- a/src/rules/jsx-no-undef.ts
+++ b/src/rules/jsx-no-undef.ts
@@ -1,3 +1,11 @@
+/**
+ * FIXME: remove this comments and import when below issue is fixed.
+ * This import is necessary for type generation due to a bug in the TypeScript compiler.
+ * See: https://github.com/microsoft/TypeScript/issues/42873
+ */
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+import type { TSESLint } from "@typescript-eslint/utils";
+
 import { TSESTree as T, ESLintUtils } from "@typescript-eslint/utils";
 import { isDOMElementName, formatList, appendImports, insertImports } from "../utils";
 

--- a/src/rules/jsx-uses-vars.ts
+++ b/src/rules/jsx-uses-vars.ts
@@ -1,3 +1,11 @@
+/**
+ * FIXME: remove this comments and import when below issue is fixed.
+ * This import is necessary for type generation due to a bug in the TypeScript compiler.
+ * See: https://github.com/microsoft/TypeScript/issues/42873
+ */
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+import type { TSESLint } from "@typescript-eslint/utils";
+
 import { TSESTree as T, ESLintUtils } from "@typescript-eslint/utils";
 
 const createRule = ESLintUtils.RuleCreator.withoutDocs;

--- a/src/rules/no-array-handlers.ts
+++ b/src/rules/no-array-handlers.ts
@@ -1,3 +1,11 @@
+/**
+ * FIXME: remove this comments and import when below issue is fixed.
+ * This import is necessary for type generation due to a bug in the TypeScript compiler.
+ * See: https://github.com/microsoft/TypeScript/issues/42873
+ */
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+import type { TSESLint } from "@typescript-eslint/utils";
+
 import { TSESTree as T, ESLintUtils } from "@typescript-eslint/utils";
 import { isDOMElementName, trace } from "../utils";
 

--- a/src/rules/no-innerhtml.ts
+++ b/src/rules/no-innerhtml.ts
@@ -1,3 +1,11 @@
+/**
+ * FIXME: remove this comments and import when below issue is fixed.
+ * This import is necessary for type generation due to a bug in the TypeScript compiler.
+ * See: https://github.com/microsoft/TypeScript/issues/42873
+ */
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+import type { TSESLint } from "@typescript-eslint/utils";
+
 import { ESLintUtils, ASTUtils } from "@typescript-eslint/utils";
 import isHtml from "is-html";
 import { jsxPropName } from "../utils";

--- a/src/rules/no-proxy-apis.ts
+++ b/src/rules/no-proxy-apis.ts
@@ -1,3 +1,11 @@
+/**
+ * FIXME: remove this comments and import when below issue is fixed.
+ * This import is necessary for type generation due to a bug in the TypeScript compiler.
+ * See: https://github.com/microsoft/TypeScript/issues/42873
+ */
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+import type { TSESLint } from "@typescript-eslint/utils";
+
 import { TSESTree as T, ESLintUtils } from "@typescript-eslint/utils";
 import { isFunctionNode, trackImports, isPropsByName, trace } from "../utils";
 

--- a/src/rules/no-react-deps.ts
+++ b/src/rules/no-react-deps.ts
@@ -1,3 +1,11 @@
+/**
+ * FIXME: remove this comments and import when below issue is fixed.
+ * This import is necessary for type generation due to a bug in the TypeScript compiler.
+ * See: https://github.com/microsoft/TypeScript/issues/42873
+ */
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+import type { TSESLint } from "@typescript-eslint/utils";
+
 import { ESLintUtils } from "@typescript-eslint/utils";
 import { isFunctionNode, trace, trackImports } from "../utils";
 

--- a/src/rules/no-unknown-namespaces.ts
+++ b/src/rules/no-unknown-namespaces.ts
@@ -1,3 +1,11 @@
+/**
+ * FIXME: remove this comments and import when below issue is fixed.
+ * This import is necessary for type generation due to a bug in the TypeScript compiler.
+ * See: https://github.com/microsoft/TypeScript/issues/42873
+ */
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+import type { TSESLint } from "@typescript-eslint/utils";
+
 import { ESLintUtils, TSESTree as T } from "@typescript-eslint/utils";
 import { isDOMElementName } from "../utils";
 

--- a/src/rules/prefer-classlist.ts
+++ b/src/rules/prefer-classlist.ts
@@ -1,3 +1,11 @@
+/**
+ * FIXME: remove this comments and import when below issue is fixed.
+ * This import is necessary for type generation due to a bug in the TypeScript compiler.
+ * See: https://github.com/microsoft/TypeScript/issues/42873
+ */
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+import type { TSESLint } from "@typescript-eslint/utils";
+
 import { ESLintUtils, TSESTree as T } from "@typescript-eslint/utils";
 import { jsxHasProp, jsxPropName } from "../utils";
 

--- a/src/rules/prefer-for.ts
+++ b/src/rules/prefer-for.ts
@@ -1,3 +1,11 @@
+/**
+ * FIXME: remove this comments and import when below issue is fixed.
+ * This import is necessary for type generation due to a bug in the TypeScript compiler.
+ * See: https://github.com/microsoft/TypeScript/issues/42873
+ */
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+import type { TSESLint } from "@typescript-eslint/utils";
+
 import { TSESTree as T, ESLintUtils, ASTUtils } from "@typescript-eslint/utils";
 import { isFunctionNode, isJSXElementOrFragment } from "../utils";
 

--- a/src/rules/prefer-show.ts
+++ b/src/rules/prefer-show.ts
@@ -1,3 +1,11 @@
+/**
+ * FIXME: remove this comments and import when below issue is fixed.
+ * This import is necessary for type generation due to a bug in the TypeScript compiler.
+ * See: https://github.com/microsoft/TypeScript/issues/42873
+ */
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+import type { TSESLint } from "@typescript-eslint/utils";
+
 import { TSESTree as T, ESLintUtils } from "@typescript-eslint/utils";
 import { isJSXElementOrFragment } from "../utils";
 

--- a/src/rules/self-closing-comp.ts
+++ b/src/rules/self-closing-comp.ts
@@ -1,3 +1,11 @@
+/**
+ * FIXME: remove this comments and import when below issue is fixed.
+ * This import is necessary for type generation due to a bug in the TypeScript compiler.
+ * See: https://github.com/microsoft/TypeScript/issues/42873
+ */
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+import type { TSESLint } from "@typescript-eslint/utils";
+
 import { TSESTree as T, ESLintUtils } from "@typescript-eslint/utils";
 import { isDOMElementName } from "../utils";
 

--- a/src/rules/style-prop.ts
+++ b/src/rules/style-prop.ts
@@ -1,3 +1,11 @@
+/**
+ * FIXME: remove this comments and import when below issue is fixed.
+ * This import is necessary for type generation due to a bug in the TypeScript compiler.
+ * See: https://github.com/microsoft/TypeScript/issues/42873
+ */
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+import type { TSESLint } from "@typescript-eslint/utils";
+
 import { TSESTree as T, ESLintUtils, ASTUtils } from "@typescript-eslint/utils";
 import kebabCase from "kebab-case";
 import { all as allCssProperties } from "known-css-properties";

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -3,6 +3,7 @@
   "exclude": ["configs", "test", "scripts", "standalone", "jest.setup.js"],
   "compilerOptions": {
     "noEmit": false,
+    "declaration": true,
     "outDir": "dist",
     "removeComments": true
   }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node16/tsconfig.json",
+  "extends": "./node_modules/@tsconfig/node20/tsconfig.json",
   "compilerOptions": {
     "forceConsistentCasingInFileNames": true,
     "isolatedModules": true,


### PR DESCRIPTION
Due to a TypeScript compiler bug, not importing unused types causes a type generation error, so I added commit 8ccc56e.
Revert 8ccc56e when following TypeScript issue mentioned in the commit message is fixed.

Fix #128