### PR TITLE
Export flat configs from root entry point

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,13 +119,19 @@ is available starting in ESLint [v8.23.0](https://github.com/eslint/eslint/relea
 use it, create an `eslint.config.js` file at the root of your project, instead of `.eslintrc.*`
 and/or `.eslintignore`.
 
+> [!IMPORTANT]
+> If you were using flat configs with a version prior to 0.13.3, please note that the entry points
+> `"eslint-plugin-solid/configs/recommended"` or `"eslint-plugin-solid/configs/typescript"`
+> have been deprecated starting with version 0.13.3. Instead, refer to the example below and
+> import from the `"eslint-plugin-solid"` root entry.
+
 ```js
 import js from "@eslint/js";
-import solid from "eslint-plugin-solid/configs/recommended";
+import solid from "eslint-plugin-solid";
 
 export default [
   js.configs.recommended, // replaces eslint:recommended
-  solid,
+  solid.configs["flat/recommended"],
 ];
 ```
 
@@ -133,22 +139,24 @@ For TypeScript:
 
 ```js
 import js from "@eslint/js";
-import solid from 'eslint-plugin-solid/configs/typescript';
-import * as tsParser from "@typescript-eslint/parser";
+import tseslint from 'typescript-eslint';
+import solid from 'eslint-plugin-solid';
 
-export default [
+export default tseslint.config( // utility for flat configuration
   js.configs.recommended,
   {
     files: ["**/*.{ts,tsx}"],
-    ...solid,
+    extends: [
+      ...tseslint.configs.base, // minimal config sets for typescript
+      solid.configs["flat/typescript"],
+    ],
     languageOptions: {
-      parser: tsParser,
       parserOptions: {
         project: 'tsconfig.json',
       },
     },
   },
-]
+);
 ```
 
 These configurations do not configure global variables in ESLint. You can do this yourself manually

--- a/configs/recommended.d.ts
+++ b/configs/recommended.d.ts
@@ -1,4 +1,4 @@
 declare module "eslint-plugin-solid/configs/recommended" {
-  const config: typeof import("../src/configs/recommended");
+  const config: typeof import("../dist/index").configs["flat/recommended"];
   export = config;
 }

--- a/configs/recommended.d.ts
+++ b/configs/recommended.d.ts
@@ -1,4 +1,9 @@
 declare module "eslint-plugin-solid/configs/recommended" {
+  /**
+   * @deprecated Please use flat configs via the root entry ("eslint-plugin-solid").
+   * Refer to the [README](https://github.com/solidjs-community/eslint-plugin-solid#flat-configuration)
+   * for more details.
+   */
   const config: typeof import("../dist/index").configs["flat/recommended"];
   export = config;
 }

--- a/configs/recommended.js
+++ b/configs/recommended.js
@@ -1,1 +1,2 @@
-module.exports = require("../dist/configs/recommended");
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+module.exports = require("../dist/index").configs["flat/recommended"];

--- a/configs/typescript.d.ts
+++ b/configs/typescript.d.ts
@@ -1,4 +1,4 @@
 declare module "eslint-plugin-solid/configs/typescript" {
-  const config: typeof import("../src/configs/typescript");
+  const config: typeof import("../dist/index").configs["flat/typescript"];
   export = config;
 }

--- a/configs/typescript.d.ts
+++ b/configs/typescript.d.ts
@@ -1,4 +1,9 @@
 declare module "eslint-plugin-solid/configs/typescript" {
+  /**
+   * @deprecated Please use flat configs via the root entry ("eslint-plugin-solid").
+   * Refer to the [README](https://github.com/solidjs-community/eslint-plugin-solid#flat-configuration)
+   * for more details.
+   */
   const config: typeof import("../dist/index").configs["flat/typescript"];
   export = config;
 }

--- a/configs/typescript.js
+++ b/configs/typescript.js
@@ -1,1 +1,2 @@
-module.exports = require("../dist/configs/typescript");
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+module.exports = require("../dist/index").configs["flat/typescript"];

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "eslint-plugin-solid": "link:",
     "eslint-v6": "npm:eslint@^6.8.0",
     "eslint-v7": "npm:eslint@^7.32.0",
+    "expect-type": "^0.19.0",
     "husky": "^8.0.3",
     "jest": "^29.7.0",
     "lint-staged": "^13.3.0",
@@ -70,7 +71,8 @@
     "prettier": "^2.8.8",
     "ts-jest": "^29.1.2",
     "ts-node": "^10.9.2",
-    "typescript": "^5.4.3"
+    "typescript": "^5.4.3",
+    "typescript-eslint": "^7.6.0"
   },
   "peerDependencies": {
     "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -79,6 +79,9 @@ devDependencies:
   eslint-v7:
     specifier: npm:eslint@^7.32.0
     version: /eslint@7.32.0
+  expect-type:
+    specifier: ^0.19.0
+    version: 0.19.0
   husky:
     specifier: ^8.0.3
     version: 8.0.3
@@ -103,6 +106,9 @@ devDependencies:
   typescript:
     specifier: ^5.4.3
     version: 5.4.3
+  typescript-eslint:
+    specifier: ^7.6.0
+    version: 7.6.0(eslint@8.57.0)(typescript@5.4.3)
 
 packages:
 
@@ -1110,6 +1116,35 @@ packages:
       - supports-color
     dev: true
 
+  /@typescript-eslint/eslint-plugin@7.6.0(@typescript-eslint/parser@7.6.0)(eslint@8.57.0)(typescript@5.4.3):
+    resolution: {integrity: sha512-gKmTNwZnblUdnTIJu3e9kmeRRzV2j1a/LUO27KNNAnIC5zjy1aSvXSRp4rVNlmAoHlQ7HzX42NbKpcSr4jF80A==}
+    engines: {node: ^18.18.0 || >=20.0.0}
+    peerDependencies:
+      '@typescript-eslint/parser': ^7.0.0
+      eslint: ^8.56.0
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@eslint-community/regexpp': 4.10.0
+      '@typescript-eslint/parser': 7.6.0(eslint@8.57.0)(typescript@5.4.3)
+      '@typescript-eslint/scope-manager': 7.6.0
+      '@typescript-eslint/type-utils': 7.6.0(eslint@8.57.0)(typescript@5.4.3)
+      '@typescript-eslint/utils': 7.6.0(eslint@8.57.0)(typescript@5.4.3)
+      '@typescript-eslint/visitor-keys': 7.6.0
+      debug: 4.3.4
+      eslint: 8.57.0
+      graphemer: 1.4.0
+      ignore: 5.3.1
+      natural-compare: 1.4.0
+      semver: 7.6.0
+      ts-api-utils: 1.3.0(typescript@5.4.3)
+      typescript: 5.4.3
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.4.3):
     resolution: {integrity: sha512-tbsV1jPne5CkFQCgPBcDOt30ItF7aJoZL997JSF7MhGQqOeT3svWRYxiqlfA5RUdlHN6Fi+EI9bxqbdyAUZjYQ==}
     engines: {node: ^16.0.0 || >=18.0.0}
@@ -1131,12 +1166,41 @@ packages:
       - supports-color
     dev: true
 
+  /@typescript-eslint/parser@7.6.0(eslint@8.57.0)(typescript@5.4.3):
+    resolution: {integrity: sha512-usPMPHcwX3ZoPWnBnhhorc14NJw9J4HpSXQX4urF2TPKG0au0XhJoZyX62fmvdHONUkmyUe74Hzm1//XA+BoYg==}
+    engines: {node: ^18.18.0 || >=20.0.0}
+    peerDependencies:
+      eslint: ^8.56.0
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@typescript-eslint/scope-manager': 7.6.0
+      '@typescript-eslint/types': 7.6.0
+      '@typescript-eslint/typescript-estree': 7.6.0(typescript@5.4.3)
+      '@typescript-eslint/visitor-keys': 7.6.0
+      debug: 4.3.4
+      eslint: 8.57.0
+      typescript: 5.4.3
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /@typescript-eslint/scope-manager@6.21.0:
     resolution: {integrity: sha512-OwLUIWZJry80O99zvqXVEioyniJMa+d2GrqpUTqi5/v5D5rOrppJVBPa0yKCblcigC0/aYAzxxqQ1B+DS2RYsg==}
     engines: {node: ^16.0.0 || >=18.0.0}
     dependencies:
       '@typescript-eslint/types': 6.21.0
       '@typescript-eslint/visitor-keys': 6.21.0
+
+  /@typescript-eslint/scope-manager@7.6.0:
+    resolution: {integrity: sha512-ngttyfExA5PsHSx0rdFgnADMYQi+Zkeiv4/ZxGYUWd0nLs63Ha0ksmp8VMxAIC0wtCFxMos7Lt3PszJssG/E6w==}
+    engines: {node: ^18.18.0 || >=20.0.0}
+    dependencies:
+      '@typescript-eslint/types': 7.6.0
+      '@typescript-eslint/visitor-keys': 7.6.0
+    dev: true
 
   /@typescript-eslint/type-utils@6.21.0(eslint@8.57.0)(typescript@5.4.3):
     resolution: {integrity: sha512-rZQI7wHfao8qMX3Rd3xqeYSMCL3SoiSQLBATSiVKARdFGCYSRvmViieZjqc58jKgs8Y8i9YvVVhRbHSTA4VBag==}
@@ -1158,9 +1222,34 @@ packages:
       - supports-color
     dev: true
 
+  /@typescript-eslint/type-utils@7.6.0(eslint@8.57.0)(typescript@5.4.3):
+    resolution: {integrity: sha512-NxAfqAPNLG6LTmy7uZgpK8KcuiS2NZD/HlThPXQRGwz6u7MDBWRVliEEl1Gj6U7++kVJTpehkhZzCJLMK66Scw==}
+    engines: {node: ^18.18.0 || >=20.0.0}
+    peerDependencies:
+      eslint: ^8.56.0
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@typescript-eslint/typescript-estree': 7.6.0(typescript@5.4.3)
+      '@typescript-eslint/utils': 7.6.0(eslint@8.57.0)(typescript@5.4.3)
+      debug: 4.3.4
+      eslint: 8.57.0
+      ts-api-utils: 1.3.0(typescript@5.4.3)
+      typescript: 5.4.3
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /@typescript-eslint/types@6.21.0:
     resolution: {integrity: sha512-1kFmZ1rOm5epu9NZEZm1kckCDGj5UJEf7P1kliH4LKu/RkwpsfqqGmY2OOcUs18lSlQBKLDYBOGxRVtrMN5lpg==}
     engines: {node: ^16.0.0 || >=18.0.0}
+
+  /@typescript-eslint/types@7.6.0:
+    resolution: {integrity: sha512-h02rYQn8J+MureCvHVVzhl69/GAfQGPQZmOMjG1KfCl7o3HtMSlPaPUAPu6lLctXI5ySRGIYk94clD/AUMCUgQ==}
+    engines: {node: ^18.18.0 || >=20.0.0}
+    dev: true
 
   /@typescript-eslint/typescript-estree@6.21.0(typescript@5.4.3):
     resolution: {integrity: sha512-6npJTkZcO+y2/kr+z0hc4HwNfrrP4kNYh57ek7yCNlrBjWQ1Y0OS7jiZTkgumrvkX5HkEKXFZkkdFNkaW2wmUQ==}
@@ -1183,6 +1272,28 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
+  /@typescript-eslint/typescript-estree@7.6.0(typescript@5.4.3):
+    resolution: {integrity: sha512-+7Y/GP9VuYibecrCQWSKgl3GvUM5cILRttpWtnAu8GNL9j11e4tbuGZmZjJ8ejnKYyBRb2ddGQ3rEFCq3QjMJw==}
+    engines: {node: ^18.18.0 || >=20.0.0}
+    peerDependencies:
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@typescript-eslint/types': 7.6.0
+      '@typescript-eslint/visitor-keys': 7.6.0
+      debug: 4.3.4
+      globby: 11.1.0
+      is-glob: 4.0.3
+      minimatch: 9.0.4
+      semver: 7.6.0
+      ts-api-utils: 1.3.0(typescript@5.4.3)
+      typescript: 5.4.3
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /@typescript-eslint/utils@6.21.0(eslint@8.57.0)(typescript@5.4.3):
     resolution: {integrity: sha512-NfWVaC8HP9T8cbKQxHcsJBY5YE1O33+jpMwN45qzWWaPDZgLIbo12toGMWnmhvCpd3sIxkpDw3Wv1B3dYrbDQQ==}
     engines: {node: ^16.0.0 || >=18.0.0}
@@ -1201,12 +1312,39 @@ packages:
       - supports-color
       - typescript
 
+  /@typescript-eslint/utils@7.6.0(eslint@8.57.0)(typescript@5.4.3):
+    resolution: {integrity: sha512-x54gaSsRRI+Nwz59TXpCsr6harB98qjXYzsRxGqvA5Ue3kQH+FxS7FYU81g/omn22ML2pZJkisy6Q+ElK8pBCA==}
+    engines: {node: ^18.18.0 || >=20.0.0}
+    peerDependencies:
+      eslint: ^8.56.0
+    dependencies:
+      '@eslint-community/eslint-utils': 4.4.0(eslint@8.57.0)
+      '@types/json-schema': 7.0.15
+      '@types/semver': 7.5.8
+      '@typescript-eslint/scope-manager': 7.6.0
+      '@typescript-eslint/types': 7.6.0
+      '@typescript-eslint/typescript-estree': 7.6.0(typescript@5.4.3)
+      eslint: 8.57.0
+      semver: 7.6.0
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+    dev: true
+
   /@typescript-eslint/visitor-keys@6.21.0:
     resolution: {integrity: sha512-JJtkDduxLi9bivAB+cYOVMtbkqdPOhZ+ZI5LC47MIRrDV4Yn2o+ZnW10Nkmr28xRpSpdJ6Sm42Hjf2+REYXm0A==}
     engines: {node: ^16.0.0 || >=18.0.0}
     dependencies:
       '@typescript-eslint/types': 6.21.0
       eslint-visitor-keys: 3.4.3
+
+  /@typescript-eslint/visitor-keys@7.6.0:
+    resolution: {integrity: sha512-4eLB7t+LlNUmXzfOu1VAIAdkjbu5xNSerURS9X/S5TUKWFRpXRQZbmtPqgKmYx8bj3J0irtQXSiWAOY82v+cgw==}
+    engines: {node: ^18.18.0 || >=20.0.0}
+    dependencies:
+      '@typescript-eslint/types': 7.6.0
+      eslint-visitor-keys: 3.4.3
+    dev: true
 
   /@ungap/structured-clone@1.2.0:
     resolution: {integrity: sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==}
@@ -2475,6 +2613,11 @@ packages:
   /exit@0.1.2:
     resolution: {integrity: sha512-Zk/eNKV2zbjpKzrsQ+n1G6poVbErQxJ0LBOJXaKZ1EViLzH+hrLu9cdXI4zw9dBQJslwBEpbQ2P1oS7nDxs6jQ==}
     engines: {node: '>= 0.8.0'}
+    dev: true
+
+  /expect-type@0.19.0:
+    resolution: {integrity: sha512-piv9wz3IrAG4Wnk2A+n2VRCHieAyOSxrRLU872Xo6nyn39kYXKDALk4OcqnvLRnFvkz659CnWC8MWZLuuQnoqg==}
+    engines: {node: '>=12.0.0'}
     dev: true
 
   /expect@29.7.0:
@@ -4077,6 +4220,13 @@ packages:
     dependencies:
       brace-expansion: 2.0.1
 
+  /minimatch@9.0.4:
+    resolution: {integrity: sha512-KqWh+VchfxcMNRAJjj2tnsSJdNbHsVgnkBhTNrW7AjVo6OvLtxw8zfT9oLw1JSohlFzJ8jCoTgaoXvJ+kHt6fw==}
+    engines: {node: '>=16 || 14 >=14.17'}
+    dependencies:
+      brace-expansion: 2.0.1
+    dev: true
+
   /minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
     dev: true
@@ -5165,6 +5315,25 @@ packages:
 
   /typedarray@0.0.6:
     resolution: {integrity: sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==}
+    dev: true
+
+  /typescript-eslint@7.6.0(eslint@8.57.0)(typescript@5.4.3):
+    resolution: {integrity: sha512-LY6vH6F1l5jpGqRtU+uK4+mOecIb4Cd4kaz1hAiJrgnNiHUA8wiw8BkJyYS+MRLM69F1QuSKwtGlQqnGl1Rc6w==}
+    engines: {node: ^18.18.0 || >=20.0.0}
+    peerDependencies:
+      eslint: ^8.56.0
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@typescript-eslint/eslint-plugin': 7.6.0(@typescript-eslint/parser@7.6.0)(eslint@8.57.0)(typescript@5.4.3)
+      '@typescript-eslint/parser': 7.6.0(eslint@8.57.0)(typescript@5.4.3)
+      '@typescript-eslint/utils': 7.6.0(eslint@8.57.0)(typescript@5.4.3)
+      eslint: 8.57.0
+      typescript: 5.4.3
+    transitivePeerDependencies:
+      - supports-color
     dev: true
 
   /typescript@5.4.3:

--- a/src/configs/recommended.ts
+++ b/src/configs/recommended.ts
@@ -6,6 +6,8 @@
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 import type { TSESLint } from "@typescript-eslint/utils";
 
+import type { Linter } from "eslint";
+
 const flat = {
   languageOptions: {
     sourceType: "module",
@@ -44,7 +46,7 @@ const flat = {
     // deprecated
     "solid/prefer-classlist": 0,
   },
-};
+} satisfies Linter.FlatConfig;
 
 const legacy = {
   env: {
@@ -53,7 +55,7 @@ const legacy = {
   },
   parserOptions: flat.languageOptions.parserOptions,
   rules: flat.rules,
-};
+} satisfies Linter.Config;
 
 const recommended = {
   flat,

--- a/src/configs/recommended.ts
+++ b/src/configs/recommended.ts
@@ -6,12 +6,7 @@
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 import type { TSESLint } from "@typescript-eslint/utils";
 
-import { plugin } from "../plugin";
-
-const recommended = {
-  plugins: {
-    solid: plugin,
-  },
+const flat = {
   languageOptions: {
     sourceType: "module",
     parserOptions: {
@@ -49,6 +44,20 @@ const recommended = {
     // deprecated
     "solid/prefer-classlist": 0,
   },
+};
+
+const legacy = {
+  env: {
+    browser: true,
+    es6: true,
+  },
+  parserOptions: flat.languageOptions.parserOptions,
+  rules: flat.rules,
+};
+
+const recommended = {
+  flat,
+  legacy,
 };
 
 export = recommended;

--- a/src/configs/typescript.ts
+++ b/src/configs/typescript.ts
@@ -8,19 +8,36 @@ import type { TSESLint } from "@typescript-eslint/utils";
 
 import recommended from "./recommended";
 
-const typescript = {
+const flat = {
   // no files; either apply to all files, or let users spread in this config
   // and specify matching patterns. This is eslint-plugin-react's take.
-  plugins: recommended.plugins,
+
   // no languageOptions; ESLint's default parser can't parse TypeScript,
   // and parsers are configured in languageOptions, so let the user handle
   // this rather than cause potential conflicts
+
   rules: {
-    ...recommended.rules,
+    ...recommended.flat.rules,
     "solid/jsx-no-undef": [2, { typescriptEnabled: true }],
     // namespaces taken care of by TS
     "solid/no-unknown-namespaces": 0,
   },
+};
+
+const legacy = {
+  env: {
+    browser: true,
+    es6: true,
+  },
+  parserOptions: {
+    sourceType: "module",
+  },
+  rules: flat.rules,
+};
+
+const typescript = {
+  flat,
+  legacy,
 };
 
 export = typescript;

--- a/src/configs/typescript.ts
+++ b/src/configs/typescript.ts
@@ -7,6 +7,7 @@
 import type { TSESLint } from "@typescript-eslint/utils";
 
 import recommended from "./recommended";
+import type { Linter } from "eslint";
 
 const flat = {
   // no files; either apply to all files, or let users spread in this config
@@ -22,7 +23,7 @@ const flat = {
     // namespaces taken care of by TS
     "solid/no-unknown-namespaces": 0,
   },
-};
+} satisfies Linter.FlatConfig;
 
 const legacy = {
   env: {
@@ -33,7 +34,7 @@ const legacy = {
     sourceType: "module",
   },
   rules: flat.rules,
-};
+} satisfies Linter.Config;
 
 const typescript = {
   flat,

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,35 +6,23 @@
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 import type { TSESLint } from "@typescript-eslint/utils";
 
-import { plugin } from "./plugin";
-import recommendedConfig from "./configs/recommended";
-import typescriptConfig from "./configs/typescript";
+import rules from "./rules";
+import recommended from "./configs/recommended";
+import typescript from "./configs/typescript";
 
-const pluginLegacy = {
-  rules: plugin.rules,
-  configs: {
-    recommended: {
-      plugins: ["solid"],
-      env: {
-        browser: true,
-        es6: true,
-      },
-      parserOptions: recommendedConfig.languageOptions.parserOptions,
-      rules: recommendedConfig.rules,
-    },
-    typescript: {
-      plugins: ["solid"],
-      env: {
-        browser: true,
-        es6: true,
-      },
-      parserOptions: {
-        sourceType: "module",
-      },
-      rules: typescriptConfig.rules,
-    },
-  },
+const plugin = {
+  configs: {},
+  rules,
 };
 
+const configs = {
+  "flat/recommended": { plugins: { solid: plugin }, ...recommended.flat },
+  "flat/typescript": { plugins: { solid: plugin }, ...typescript.flat },
+  recommended: { plugins: ["solid"], ...recommended.legacy },
+  typescript: { plugins: ["solid"], ...typescript.legacy },
+};
+
+plugin.configs = configs;
+
 // Must be `export = ` for eslint to load everything
-export = pluginLegacy;
+export = plugin;

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,7 @@ import type { TSESLint } from "@typescript-eslint/utils";
 import rules from "./rules";
 import recommended from "./configs/recommended";
 import typescript from "./configs/typescript";
+import type { Linter } from "eslint";
 
 const plugin = {
   configs: {},
@@ -16,13 +17,12 @@ const plugin = {
 };
 
 const configs = {
-  "flat/recommended": { plugins: { solid: plugin }, ...recommended.flat },
-  "flat/typescript": { plugins: { solid: plugin }, ...typescript.flat },
-  recommended: { plugins: ["solid"], ...recommended.legacy },
-  typescript: { plugins: ["solid"], ...typescript.legacy },
+  "flat/recommended": { plugins: { solid: plugin }, ...recommended.flat } as unknown as Linter.FlatConfig,
+  "flat/typescript": { plugins: { solid: plugin }, ...typescript.flat } as unknown as Linter.FlatConfig,
+  recommended: { plugins: ["solid"], ...recommended.legacy } as Linter.Config,
+  typescript: { plugins: ["solid"], ...typescript.legacy } as Linter.Config,
 };
-
 plugin.configs = configs;
 
 // Must be `export = ` for eslint to load everything
-export = plugin;
+export = plugin as typeof plugin & { configs: typeof configs };

--- a/src/rules.ts
+++ b/src/rules.ts
@@ -28,7 +28,7 @@ import styleProp from "./rules/style-prop";
 import noArrayHandlers from "./rules/no-array-handlers";
 // import validateJsxNesting from "./rules/validate-jsx-nesting";
 
-const allRules = {
+const rules = {
   "components-return-once": componentsReturnOnce,
   "event-handlers": eventHandlers,
   imports,
@@ -52,4 +52,4 @@ const allRules = {
   // "validate-jsx-nesting": validateJsxNesting
 };
 
-export const plugin = { rules: allRules };
+export = rules;

--- a/test/fixture.test.ts
+++ b/test/fixture.test.ts
@@ -4,6 +4,7 @@ import { ESLint } from "eslint";
 import { FlatESLint } from "eslint/use-at-your-own-risk";
 
 import * as tsParser from "@typescript-eslint/parser";
+import plugin from "eslint-plugin-solid";
 import recommendedConfig from "eslint-plugin-solid/configs/recommended";
 import typescriptConfig from "eslint-plugin-solid/configs/typescript";
 
@@ -38,7 +39,10 @@ test.concurrent("fixture", async () => {
   expect(results.filter((result) => result.filePath === jsxUndefPath).length).toBe(1);
 });
 
-test.concurrent("fixture (flat)", async () => {
+test.concurrent.each([
+  [plugin.configs["flat/recommended"], plugin.configs["flat/typescript"]],
+  [recommendedConfig, typescriptConfig],
+])("fixture (flat)", async (recommendedConfig, typescriptConfig) => {
   const eslint = new FlatESLint({
     cwd,
     overrideConfigFile: true,

--- a/test/typing.test.ts
+++ b/test/typing.test.ts
@@ -1,0 +1,18 @@
+import { expectTypeOf } from "expect-type";
+import tseslint from "typescript-eslint";
+import plugin from "eslint-plugin-solid";
+
+import type { Linter } from "eslint";
+
+test.concurrent("typing", () => {
+  expectTypeOf([
+    plugin.configs["flat/recommended"],
+    plugin.configs["flat/typescript"],
+  ]).toMatchTypeOf<Linter.FlatConfig[]>();
+
+  tseslint.config(plugin.configs["flat/recommended"], plugin.configs["flat/typescript"]);
+
+  tseslint.config({
+    extends: [plugin.configs["flat/recommended"], plugin.configs["flat/typescript"]],
+  });
+});


### PR DESCRIPTION
As described [here](https://github.com/solidjs-community/eslint-plugin-solid/issues/128#issuecomment-1987313618), most other plugins that support flat configs export their flat configs from the root entry point. Therefore, to avoid confusion among users, this plugin also exports its flat configs from the root entry point.

Accordingly, I updated the README and deprecated the previous entry points.
