### PR TITLE
Expose flat configs from package root as .configs['flat/*'].

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ For TypeScript:
 
 ```js
 import js from "@eslint/js";
-import solid from 'eslint-plugin-solid/configs/typescript';
+import solid from "eslint-plugin-solid/configs/typescript";
 import * as tsParser from "@typescript-eslint/parser";
 
 export default [
@@ -144,11 +144,11 @@ export default [
     languageOptions: {
       parser: tsParser,
       parserOptions: {
-        project: 'tsconfig.json',
+        project: "tsconfig.json",
       },
     },
   },
-]
+];
 ```
 
 These configurations do not configure global variables in ESLint. You can do this yourself manually
@@ -158,6 +158,8 @@ as well as at least ES2015.
 
 Note for the ESLint VSCode Extension: Enable the "Use Flat Config" setting for your workspace to
 enable Flat Config support.
+
+Flat configs are also available as `plugin.configs['flat/recommended']` and `plugin.configs['flat/typescript']`, after using `import plugin from 'eslint-plugin-solid'`.
 
 ## Rules
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -33,6 +33,8 @@ const pluginLegacy = {
       },
       rules: typescriptConfig.rules,
     },
+    "flat/recommended": recommendedConfig,
+    "flat/typescript": typescriptConfig,
   },
 };
 

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -28,6 +28,11 @@ import styleProp from "./rules/style-prop";
 import noArrayHandlers from "./rules/no-array-handlers";
 // import validateJsxNesting from "./rules/validate-jsx-nesting";
 
+// Use require() so that `package.json` doesn't get copied to `dist`
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { name, version } = require("../package.json");
+const meta = { name, version };
+
 const allRules = {
   "components-return-once": componentsReturnOnce,
   "event-handlers": eventHandlers,
@@ -52,4 +57,4 @@ const allRules = {
   // "validate-jsx-nesting": validateJsxNesting
 };
 
-export const plugin = { rules: allRules };
+export const plugin = { meta, rules: allRules };

--- a/test/fixture.test.ts
+++ b/test/fixture.test.ts
@@ -6,6 +6,7 @@ import { FlatESLint } from "eslint/use-at-your-own-risk";
 import * as tsParser from "@typescript-eslint/parser";
 import recommendedConfig from "eslint-plugin-solid/configs/recommended";
 import typescriptConfig from "eslint-plugin-solid/configs/typescript";
+import plugin from "eslint-plugin-solid";
 
 const cwd = path.resolve("test", "fixture");
 const validDir = path.join(cwd, "valid");
@@ -65,4 +66,25 @@ test.concurrent("fixture (flat)", async () => {
   results.forEach(checkResult);
 
   expect(results.filter((result) => result.filePath === jsxUndefPath).length).toBe(1);
+});
+
+describe("config format", () => {
+  test("flat config has meta", () => {
+    expect(recommendedConfig.plugins.solid.meta.name).toBe("eslint-plugin-solid");
+    expect(recommendedConfig.plugins.solid.meta.version).toEqual(expect.any(String));
+    expect(typescriptConfig.plugins.solid.meta.name).toBe("eslint-plugin-solid");
+    expect(typescriptConfig.plugins.solid.meta.version).toEqual(expect.any(String));
+  });
+
+  test('flat configs are also exposed on plugin.configs["flat/*"]', () => {
+    // include flat configs on legacy config object with `flat/` prefix. The `fixture (flat)` test
+    // passing means that an equivalent config using `configs["flat/*"]` will also pass.
+    expect(plugin.configs["flat/recommended"]).toBe(recommendedConfig);
+    expect(plugin.configs["flat/typescript"]).toBe(typescriptConfig);
+  });
+
+  test("legacy configs use strings, not modules", () => {
+    expect(plugin.configs.recommended.plugins).toStrictEqual(["solid"]);
+    expect(plugin.configs.typescript.plugins).toStrictEqual(["solid"]);
+  });
 });


### PR DESCRIPTION
Follow up PR to #135.
