### PR TITLE
fix(deps): bump eslint peer dep to include v9

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "vitest": "^1.5.2"
   },
   "peerDependencies": {
-    "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
+    "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0 || ^9.0.0"
   },
   "lint-staged": {
     "*!(test).{js,jsx,ts,tsx}": [


### PR DESCRIPTION
since `v14` added support for v9, this should be reflected in the peer dependencies.