### PR TITLE
Update Regex that ignores untracked Scopes

### DIFF
--- a/packages/eslint-plugin-solid/src/rules/reactivity.ts
+++ b/packages/eslint-plugin-solid/src/rules/reactivity.ts
@@ -575,7 +575,7 @@ export default createRule<Options, MessageIds>({
             });
           } else if (
             parent.property.type === "Identifier" &&
-            /^(?:initial|default|static)[A-Z]/.test(parent.property.name)
+            /^(?:initial|default|static[A-Z])/.test(parent.property.name)
           ) {
             // We're using a prop with a name that starts with `initial` or
             // `default`, like `props.initialCount`. We'll refrain from warning


### PR DESCRIPTION
Fix #151

Not sure if this regex is ok, it seemed like the easiest and cleanest option but technicaly `initialother` is now also accepted, we could also make sure that if the word is `default` it is followed by a capital Letter.