### PR TITLE
Fix rule documentation URLs.

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -55,7 +55,7 @@ export default tseslint.config(
         "error",
         {
           pattern:
-            "https://github.com/solidjs-community/eslint-plugin-solid/blob/main/docs/{{name}}.md",
+            "https://github.com/solidjs-community/eslint-plugin-solid/blob/main/packages/eslint-plugin-solid/docs/{{name}}.md",
         },
       ],
     },

--- a/packages/eslint-plugin-solid/src/rules/components-return-once.ts
+++ b/packages/eslint-plugin-solid/src/rules/components-return-once.ts
@@ -34,7 +34,7 @@ export default createRule({
     docs: {
       description:
         "Disallow early returns in components. Solid components only run once, and so conditionals should be inside JSX.",
-      url: "https://github.com/solidjs-community/eslint-plugin-solid/blob/main/docs/components-return-once.md",
+      url: "https://github.com/solidjs-community/eslint-plugin-solid/blob/main/packages/eslint-plugin-solid/docs/components-return-once.md",
     },
     fixable: "code",
     schema: [],

--- a/packages/eslint-plugin-solid/src/rules/event-handlers.ts
+++ b/packages/eslint-plugin-solid/src/rules/event-handlers.ts
@@ -116,7 +116,7 @@ export default createRule<Options, MessageIds>({
     docs: {
       description:
         "Enforce naming DOM element event handlers consistently and prevent Solid's analysis from misunderstanding whether a prop should be an event handler.",
-      url: "https://github.com/solidjs-community/eslint-plugin-solid/blob/main/docs/event-handlers.md",
+      url: "https://github.com/solidjs-community/eslint-plugin-solid/blob/main/packages/eslint-plugin-solid/docs/event-handlers.md",
     },
     fixable: "code",
     hasSuggestions: true,

--- a/packages/eslint-plugin-solid/src/rules/imports.ts
+++ b/packages/eslint-plugin-solid/src/rules/imports.ts
@@ -130,7 +130,7 @@ export default createRule({
     docs: {
       description:
         'Enforce consistent imports from "solid-js", "solid-js/web", and "solid-js/store".',
-      url: "https://github.com/solidjs-community/eslint-plugin-solid/blob/main/docs/imports.md",
+      url: "https://github.com/solidjs-community/eslint-plugin-solid/blob/main/packages/eslint-plugin-solid/docs/imports.md",
     },
     fixable: "code",
     schema: [],

--- a/packages/eslint-plugin-solid/src/rules/jsx-no-duplicate-props.ts
+++ b/packages/eslint-plugin-solid/src/rules/jsx-no-duplicate-props.ts
@@ -24,7 +24,7 @@ export default createRule<Options, MessageIds>({
     type: "problem",
     docs: {
       description: "Disallow passing the same prop twice in JSX.",
-      url: "https://github.com/solidjs-community/eslint-plugin-solid/blob/main/docs/jsx-no-duplicate-props.md",
+      url: "https://github.com/solidjs-community/eslint-plugin-solid/blob/main/packages/eslint-plugin-solid/docs/jsx-no-duplicate-props.md",
     },
     schema: [
       {

--- a/packages/eslint-plugin-solid/src/rules/jsx-no-script-url.ts
+++ b/packages/eslint-plugin-solid/src/rules/jsx-no-script-url.ts
@@ -32,7 +32,7 @@ export default createRule({
     type: "problem",
     docs: {
       description: "Disallow javascript: URLs.",
-      url: "https://github.com/solidjs-community/eslint-plugin-solid/blob/main/docs/jsx-no-script-url.md",
+      url: "https://github.com/solidjs-community/eslint-plugin-solid/blob/main/packages/eslint-plugin-solid/docs/jsx-no-script-url.md",
     },
     schema: [],
     messages: {

--- a/packages/eslint-plugin-solid/src/rules/jsx-no-undef.ts
+++ b/packages/eslint-plugin-solid/src/rules/jsx-no-undef.ts
@@ -33,7 +33,7 @@ export default createRule<Options, MessageIds>({
     type: "problem",
     docs: {
       description: "Disallow references to undefined variables in JSX. Handles custom directives.",
-      url: "https://github.com/solidjs-community/eslint-plugin-solid/blob/main/docs/jsx-no-undef.md",
+      url: "https://github.com/solidjs-community/eslint-plugin-solid/blob/main/packages/eslint-plugin-solid/docs/jsx-no-undef.md",
     },
     fixable: "code",
     schema: [

--- a/packages/eslint-plugin-solid/src/rules/jsx-uses-vars.ts
+++ b/packages/eslint-plugin-solid/src/rules/jsx-uses-vars.ts
@@ -23,7 +23,7 @@ export default createRule({
     docs: {
       // eslint-disable-next-line eslint-plugin/require-meta-docs-description
       description: "Prevent variables used in JSX from being marked as unused.",
-      url: "https://github.com/solidjs-community/eslint-plugin-solid/blob/main/docs/jsx-uses-vars.md",
+      url: "https://github.com/solidjs-community/eslint-plugin-solid/blob/main/packages/eslint-plugin-solid/docs/jsx-uses-vars.md",
     },
     schema: [],
     // eslint-disable-next-line eslint-plugin/prefer-message-ids

--- a/packages/eslint-plugin-solid/src/rules/no-array-handlers.ts
+++ b/packages/eslint-plugin-solid/src/rules/no-array-handlers.ts
@@ -16,7 +16,7 @@ export default createRule({
     type: "problem",
     docs: {
       description: "Disallow usage of type-unsafe event handlers.",
-      url: "https://github.com/solidjs-community/eslint-plugin-solid/blob/main/docs/no-array-handlers.md",
+      url: "https://github.com/solidjs-community/eslint-plugin-solid/blob/main/packages/eslint-plugin-solid/docs/no-array-handlers.md",
     },
     schema: [],
     messages: {

--- a/packages/eslint-plugin-solid/src/rules/no-destructure.ts
+++ b/packages/eslint-plugin-solid/src/rules/no-destructure.ts
@@ -46,7 +46,7 @@ export default createRule({
     docs: {
       description:
         "Disallow destructuring props. In Solid, props must be used with property accesses (`props.foo`) to preserve reactivity. This rule only tracks destructuring in the parameter list.",
-      url: "https://github.com/solidjs-community/eslint-plugin-solid/blob/main/docs/no-destructure.md",
+      url: "https://github.com/solidjs-community/eslint-plugin-solid/blob/main/packages/eslint-plugin-solid/docs/no-destructure.md",
     },
     fixable: "code",
     schema: [],

--- a/packages/eslint-plugin-solid/src/rules/no-innerhtml.ts
+++ b/packages/eslint-plugin-solid/src/rules/no-innerhtml.ts
@@ -22,7 +22,7 @@ export default createRule<Options, MessageIds>({
     docs: {
       description:
         "Disallow usage of the innerHTML attribute, which can often lead to security vulnerabilities.",
-      url: "https://github.com/solidjs-community/eslint-plugin-solid/blob/main/docs/no-innerhtml.md",
+      url: "https://github.com/solidjs-community/eslint-plugin-solid/blob/main/packages/eslint-plugin-solid/docs/no-innerhtml.md",
     },
     fixable: "code",
     hasSuggestions: true,

--- a/packages/eslint-plugin-solid/src/rules/no-proxy-apis.ts
+++ b/packages/eslint-plugin-solid/src/rules/no-proxy-apis.ts
@@ -17,7 +17,7 @@ export default createRule({
     docs: {
       description:
         "Disallow usage of APIs that use ES6 Proxies, only to target environments that don't support them.",
-      url: "https://github.com/solidjs-community/eslint-plugin-solid/blob/main/docs/no-proxy-apis.md",
+      url: "https://github.com/solidjs-community/eslint-plugin-solid/blob/main/packages/eslint-plugin-solid/docs/no-proxy-apis.md",
     },
     schema: [],
     messages: {

--- a/packages/eslint-plugin-solid/src/rules/no-react-deps.ts
+++ b/packages/eslint-plugin-solid/src/rules/no-react-deps.ts
@@ -16,7 +16,7 @@ export default createRule({
     type: "problem",
     docs: {
       description: "Disallow usage of dependency arrays in `createEffect` and `createMemo`.",
-      url: "https://github.com/solidjs-community/eslint-plugin-solid/blob/main/docs/no-react-deps.md",
+      url: "https://github.com/solidjs-community/eslint-plugin-solid/blob/main/packages/eslint-plugin-solid/docs/no-react-deps.md",
     },
     fixable: "code",
     schema: [],

--- a/packages/eslint-plugin-solid/src/rules/no-react-specific-props.ts
+++ b/packages/eslint-plugin-solid/src/rules/no-react-specific-props.ts
@@ -14,7 +14,7 @@ export default createRule({
     docs: {
       description:
         "Disallow usage of React-specific `className`/`htmlFor` props, which were deprecated in v1.4.0.",
-      url: "https://github.com/solidjs-community/eslint-plugin-solid/blob/main/docs/no-react-specific-props.md",
+      url: "https://github.com/solidjs-community/eslint-plugin-solid/blob/main/packages/eslint-plugin-solid/docs/no-react-specific-props.md",
     },
     fixable: "code",
     schema: [],

--- a/packages/eslint-plugin-solid/src/rules/no-unknown-namespaces.ts
+++ b/packages/eslint-plugin-solid/src/rules/no-unknown-namespaces.ts
@@ -24,7 +24,7 @@ export default createRule<Options, MessageIds>({
     docs: {
       description:
         "Enforce using only Solid-specific namespaced attribute names (i.e. `'on:'` in `<div on:click={...} />`).",
-      url: "https://github.com/solidjs-community/eslint-plugin-solid/blob/main/docs/no-unknown-namespaces.md",
+      url: "https://github.com/solidjs-community/eslint-plugin-solid/blob/main/packages/eslint-plugin-solid/docs/no-unknown-namespaces.md",
     },
     hasSuggestions: true,
     schema: [

--- a/packages/eslint-plugin-solid/src/rules/prefer-classlist.ts
+++ b/packages/eslint-plugin-solid/src/rules/prefer-classlist.ts
@@ -20,7 +20,7 @@ export default createRule<Options, MessageIds>({
     docs: {
       description:
         "Enforce using the classlist prop over importing a classnames helper. The classlist prop accepts an object `{ [class: string]: boolean }` just like classnames.",
-      url: "https://github.com/solidjs-community/eslint-plugin-solid/blob/main/docs/prefer-classlist.md",
+      url: "https://github.com/solidjs-community/eslint-plugin-solid/blob/main/packages/eslint-plugin-solid/docs/prefer-classlist.md",
     },
     fixable: "code",
     deprecated: true,

--- a/packages/eslint-plugin-solid/src/rules/prefer-for.ts
+++ b/packages/eslint-plugin-solid/src/rules/prefer-for.ts
@@ -18,7 +18,7 @@ export default createRule({
     docs: {
       description:
         "Enforce using Solid's `<For />` component for mapping an array to JSX elements.",
-      url: "https://github.com/solidjs-community/eslint-plugin-solid/blob/main/docs/prefer-for.md",
+      url: "https://github.com/solidjs-community/eslint-plugin-solid/blob/main/packages/eslint-plugin-solid/docs/prefer-for.md",
     },
     fixable: "code",
     schema: [],

--- a/packages/eslint-plugin-solid/src/rules/prefer-show.ts
+++ b/packages/eslint-plugin-solid/src/rules/prefer-show.ts
@@ -20,7 +20,7 @@ export default createRule({
     docs: {
       description:
         "Enforce using Solid's `<Show />` component for conditionally showing content. Solid's compiler covers this case, so it's a stylistic rule only.",
-      url: "https://github.com/solidjs-community/eslint-plugin-solid/blob/main/docs/prefer-show.md",
+      url: "https://github.com/solidjs-community/eslint-plugin-solid/blob/main/packages/eslint-plugin-solid/docs/prefer-show.md",
     },
     fixable: "code",
     schema: [],

--- a/packages/eslint-plugin-solid/src/rules/reactivity.ts
+++ b/packages/eslint-plugin-solid/src/rules/reactivity.ts
@@ -237,7 +237,7 @@ export default createRule<Options, MessageIds>({
     docs: {
       description:
         "Enforce that reactivity (props, signals, memos, etc.) is properly used, so changes in those values will be tracked and update the view as expected.",
-      url: "https://github.com/solidjs-community/eslint-plugin-solid/blob/main/docs/reactivity.md",
+      url: "https://github.com/solidjs-community/eslint-plugin-solid/blob/main/packages/eslint-plugin-solid/docs/reactivity.md",
     },
     schema: [
       {

--- a/packages/eslint-plugin-solid/src/rules/self-closing-comp.ts
+++ b/packages/eslint-plugin-solid/src/rules/self-closing-comp.ts
@@ -52,7 +52,7 @@ export default createRule<Options, MessageIds>({
     type: "layout",
     docs: {
       description: "Disallow extra closing tags for components without children.",
-      url: "https://github.com/solidjs-community/eslint-plugin-solid/blob/main/docs/self-closing-comp.md",
+      url: "https://github.com/solidjs-community/eslint-plugin-solid/blob/main/packages/eslint-plugin-solid/docs/self-closing-comp.md",
     },
     fixable: "code",
     schema: [

--- a/packages/eslint-plugin-solid/src/rules/style-prop.ts
+++ b/packages/eslint-plugin-solid/src/rules/style-prop.ts
@@ -28,7 +28,7 @@ export default createRule<Options, MessageIds>({
       description:
         "Require CSS properties in the `style` prop to be valid and kebab-cased (ex. 'font-size'), not camel-cased (ex. 'fontSize') like in React, " +
         "and that property values with dimensions are strings, not numbers with implicit 'px' units.",
-      url: "https://github.com/solidjs-community/eslint-plugin-solid/blob/main/docs/style-prop.md",
+      url: "https://github.com/solidjs-community/eslint-plugin-solid/blob/main/packages/eslint-plugin-solid/docs/style-prop.md",
     },
     fixable: "code",
     schema: [


### PR DESCRIPTION
The path to each rule doc markdown file was changed when converting to a mono repo. Update the auto fixable lint rule to refer to the right spot.