### PR TITLE
Server function rules for Solid 2.0 (v0.17.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,9 +113,11 @@ export default [
 If your project targets Solid 2.0, use the `v2` configuration. It sets
 `settings: { solid: { version: 2 } }`, which switches the version-aware rules (`reactivity`,
 `imports`, `no-unknown-namespaces`, `event-handlers`, `jsx-no-undef`) to strict 2.0 semantics, and
-enables the 2.0-specific rules: `removed-api`, `no-single-arg-create-effect`, `no-accessor-as-prop`
-as errors and `prefer-structured-class` as a warning. This is the config the official Solid 2.0
-templates ship with.
+enables the 2.0-specific rules: `removed-api`, `no-single-arg-create-effect`, `no-accessor-as-prop`,
+and the server function rules (`valid-use-server`, `require-async-server-function`,
+`no-invalid-server-capture`, `no-browser-globals-in-server-function`) as errors and
+`prefer-structured-class` as a warning. This is the config the official Solid 2.0 templates ship
+with.
 
 ```js
 import js from "@eslint/js";
@@ -190,7 +192,9 @@ the plugin to `jsPlugins` in your `.oxlintrc.json` and enable the rules you want
 For Solid 2.0 projects, add `"settings": { "solid": { "version": 2 } }` to activate the
 version-aware rule behavior, and enable the 2.0 rules (`solid/removed-api`,
 `solid/no-single-arg-create-effect`, `solid/no-accessor-as-prop`,
-`solid/prefer-structured-class`).
+`solid/prefer-structured-class`, and the server function rules `solid/valid-use-server`,
+`solid/require-async-server-function`, `solid/no-invalid-server-capture`, and
+`solid/no-browser-globals-in-server-function`).
 
 ## Rules
 
@@ -210,8 +214,10 @@ version-aware rule behavior, and enable the 2.0 rules (`solid/removed-api`,
 | ✔ |  | [solid/jsx-uses-vars](/packages/eslint-plugin-solid/docs/jsx-uses-vars.md) | Prevent variables used in JSX from being marked as unused. |
 |  |  | [solid/no-accessor-as-prop](/packages/eslint-plugin-solid/docs/no-accessor-as-prop.md) | Disallow passing uncalled signal accessors or other functions as value-typed DOM element attributes. |
 |  |  | [solid/no-array-handlers](/packages/eslint-plugin-solid/docs/no-array-handlers.md) | Disallow usage of type-unsafe event handlers. |
+|  |  | [solid/no-browser-globals-in-server-function](/packages/eslint-plugin-solid/docs/no-browser-globals-in-server-function.md) | Disallow browser-only globals inside server functions, which run exclusively on the server. |
 | ✔ | 🔧 | [solid/no-destructure](/packages/eslint-plugin-solid/docs/no-destructure.md) | Disallow destructuring props. In Solid, props must be used with property accesses (`props.foo`) to preserve reactivity. This rule only tracks destructuring in the parameter list. |
 | ✔ | 🔧 | [solid/no-innerhtml](/packages/eslint-plugin-solid/docs/no-innerhtml.md) | Disallow usage of the innerHTML attribute, which can often lead to security vulnerabilities. |
+|  |  | [solid/no-invalid-server-capture](/packages/eslint-plugin-solid/docs/no-invalid-server-capture.md) | Disallow server functions from capturing variables in enclosing non-module scopes, mirroring the compiler's build-time validation. |
 |  |  | [solid/no-module-scope-reactive-primitive](/packages/eslint-plugin-solid/docs/no-module-scope-reactive-primitive.md) | Disallow reactive primitives at module scope, where state is shared across SSR requests. |
 |  |  | [solid/no-proxy-apis](/packages/eslint-plugin-solid/docs/no-proxy-apis.md) | Disallow usage of APIs that use ES6 Proxies, only to target environments that don't support them. |
 | ✔ | 🔧 | [solid/no-react-deps](/packages/eslint-plugin-solid/docs/no-react-deps.md) | Disallow usage of dependency arrays in `createEffect` and `createMemo`. |
@@ -226,8 +232,10 @@ version-aware rule behavior, and enable the 2.0 rules (`solid/removed-api`,
 |  |  | [solid/prefer-structured-class](/packages/eslint-plugin-solid/docs/prefer-structured-class.md) | Enforce using the structured array/object forms of the `class` prop over manually-built class strings. |
 | ✔ |  | [solid/reactivity](/packages/eslint-plugin-solid/docs/reactivity.md) | Enforce that reactivity (props, signals, memos, etc.) is properly used, so changes in those values will be tracked and update the view as expected. |
 |  | 🔧 | [solid/removed-api](/packages/eslint-plugin-solid/docs/removed-api.md) | Disallow Solid 1.x APIs that were removed or renamed in Solid 2.0, with migration guidance. |
+|  | 🔧 | [solid/require-async-server-function](/packages/eslint-plugin-solid/docs/require-async-server-function.md) | Require server functions to be async, matching their client-side contract. |
 | ✔ | 🔧 | [solid/self-closing-comp](/packages/eslint-plugin-solid/docs/self-closing-comp.md) | Disallow extra closing tags for components without children. |
 | ✔ | 🔧 | [solid/style-prop](/packages/eslint-plugin-solid/docs/style-prop.md) | Require CSS properties in the `style` prop to be valid and kebab-cased (ex. 'font-size'), not camel-cased (ex. 'fontSize') like in React, and that property values with dimensions are strings, not numbers with implicit 'px' units. |
+|  |  | [solid/valid-use-server](/packages/eslint-plugin-solid/docs/valid-use-server.md) | Enforce that "use server" directives are placed where the compiler honors them, and that module-level directive files export working server functions. |
 <!-- end-doc-gen -->
 
 ## Troubleshooting

--- a/README.md
+++ b/README.md
@@ -265,7 +265,7 @@ If you want to pin a minor version, use a tilde in your `package.json`.
 
 <!-- doc-gen TILDE -->
 ```diff
-- "eslint-plugin-solid": "^0.16.1"
-+ "eslint-plugin-solid": "~0.16.1"
+- "eslint-plugin-solid": "^0.17.0"
++ "eslint-plugin-solid": "~0.17.0"
 ```
 <!-- end-doc-gen -->

--- a/packages/eslint-plugin-solid/CHANGELOG.md
+++ b/packages/eslint-plugin-solid/CHANGELOG.md
@@ -1,5 +1,48 @@
 # Changelog
 
+## 0.17.0
+
+Server functions are core in Solid 2.0, so the plugin now lints them. Four new rules cover the
+`"use server"` directive's silent failure modes — all enabled as errors in the `v2` and
+`v2-strict` configs, and verified against the official Solid 2.0 templates (zero findings) and
+under Oxlint.
+
+### New Rules
+
+- **`solid/valid-use-server`.** The compiler only honors `"use server"` in specific positions and
+  silently ignores it everywhere else — often shipping database access or secrets to the client
+  without any error. Flags directives that aren't in the directive prologue (after other
+  statements, inside plain blocks), template-literal "directives", and directives in positions
+  the compiler never extracts (object methods, getters/setters, class methods). For module-level
+  directive files, also flags non-function exports (which fail at server boot) and calls to
+  client declaration wrappers (`GET`, `live`, `withMeta` from `@solidjs/web`; `query`, `action`,
+  `liveQuery` from `@solidjs/router`), whose client-side behavior is silently compiled out in
+  such files. A `clientWrappers` option adds project-specific wrapper names, with `*` wildcard
+  and `/regex/` support.
+- **`solid/require-async-server-function`.** On the client every server function call resolves a
+  Promise, but during SSR the function is called in-process and returns synchronously — so a
+  non-async server function observes two different return types, and TypeScript only sees one of
+  them. Covers function-level directives and all exports of module-level directive files
+  (including `export { name }` specifiers). Autofixes by inserting `async`.
+- **`solid/no-invalid-server-capture`.** An editor-time mirror of the compiler's closure-capture
+  validation: server functions cannot capture variables from intermediate scopes (component
+  state, enclosing function parameters), because the extracted function is hoisted to module
+  level on the server and becomes a network proxy on the client. The compiler already rejects
+  this at build time; the rule reports the same captures as you type. Module top-level bindings,
+  imports, globals, own params/locals, named-function-expression self-references, and TS
+  type-only references are all allowed.
+- **`solid/no-browser-globals-in-server-function`.** Flags unambiguous browser-only globals
+  (`window`, `document`, `localStorage`, etc.) inside server functions, which only run on the
+  server. The list is deliberately conservative — server runtimes provide `fetch`, `crypto`,
+  `URL`, and even `navigator`, so those never warn — and shadowing bindings and `typeof window`
+  guards are ignored. In module-level directive files, the whole module is checked.
+
+### Internal
+
+- `customReactiveFunctions`-style pattern matching (exact names, `*` wildcards, `/regex/`
+  strings) was extracted into a shared `createNameMatcher` utility, now used by both
+  `solid/reactivity` and `solid/valid-use-server`.
+
 ## 0.16.1
 
 A precision pass over `solid/reactivity`, driven by the longest-standing false-positive reports

--- a/packages/eslint-plugin-solid/README.md
+++ b/packages/eslint-plugin-solid/README.md
@@ -113,9 +113,11 @@ export default [
 If your project targets Solid 2.0, use the `v2` configuration. It sets
 `settings: { solid: { version: 2 } }`, which switches the version-aware rules (`reactivity`,
 `imports`, `no-unknown-namespaces`, `event-handlers`, `jsx-no-undef`) to strict 2.0 semantics, and
-enables the 2.0-specific rules: `removed-api`, `no-single-arg-create-effect`, `no-accessor-as-prop`
-as errors and `prefer-structured-class` as a warning. This is the config the official Solid 2.0
-templates ship with.
+enables the 2.0-specific rules: `removed-api`, `no-single-arg-create-effect`, `no-accessor-as-prop`,
+and the server function rules (`valid-use-server`, `require-async-server-function`,
+`no-invalid-server-capture`, `no-browser-globals-in-server-function`) as errors and
+`prefer-structured-class` as a warning. This is the config the official Solid 2.0 templates ship
+with.
 
 ```js
 import js from "@eslint/js";
@@ -190,7 +192,9 @@ the plugin to `jsPlugins` in your `.oxlintrc.json` and enable the rules you want
 For Solid 2.0 projects, add `"settings": { "solid": { "version": 2 } }` to activate the
 version-aware rule behavior, and enable the 2.0 rules (`solid/removed-api`,
 `solid/no-single-arg-create-effect`, `solid/no-accessor-as-prop`,
-`solid/prefer-structured-class`).
+`solid/prefer-structured-class`, and the server function rules `solid/valid-use-server`,
+`solid/require-async-server-function`, `solid/no-invalid-server-capture`, and
+`solid/no-browser-globals-in-server-function`).
 
 ## Rules
 
@@ -210,8 +214,10 @@ version-aware rule behavior, and enable the 2.0 rules (`solid/removed-api`,
 | ✔ |  | [solid/jsx-uses-vars](/packages/eslint-plugin-solid/docs/jsx-uses-vars.md) | Prevent variables used in JSX from being marked as unused. |
 |  |  | [solid/no-accessor-as-prop](/packages/eslint-plugin-solid/docs/no-accessor-as-prop.md) | Disallow passing uncalled signal accessors or other functions as value-typed DOM element attributes. |
 |  |  | [solid/no-array-handlers](/packages/eslint-plugin-solid/docs/no-array-handlers.md) | Disallow usage of type-unsafe event handlers. |
+|  |  | [solid/no-browser-globals-in-server-function](/packages/eslint-plugin-solid/docs/no-browser-globals-in-server-function.md) | Disallow browser-only globals inside server functions, which run exclusively on the server. |
 | ✔ | 🔧 | [solid/no-destructure](/packages/eslint-plugin-solid/docs/no-destructure.md) | Disallow destructuring props. In Solid, props must be used with property accesses (`props.foo`) to preserve reactivity. This rule only tracks destructuring in the parameter list. |
 | ✔ | 🔧 | [solid/no-innerhtml](/packages/eslint-plugin-solid/docs/no-innerhtml.md) | Disallow usage of the innerHTML attribute, which can often lead to security vulnerabilities. |
+|  |  | [solid/no-invalid-server-capture](/packages/eslint-plugin-solid/docs/no-invalid-server-capture.md) | Disallow server functions from capturing variables in enclosing non-module scopes, mirroring the compiler's build-time validation. |
 |  |  | [solid/no-module-scope-reactive-primitive](/packages/eslint-plugin-solid/docs/no-module-scope-reactive-primitive.md) | Disallow reactive primitives at module scope, where state is shared across SSR requests. |
 |  |  | [solid/no-proxy-apis](/packages/eslint-plugin-solid/docs/no-proxy-apis.md) | Disallow usage of APIs that use ES6 Proxies, only to target environments that don't support them. |
 | ✔ | 🔧 | [solid/no-react-deps](/packages/eslint-plugin-solid/docs/no-react-deps.md) | Disallow usage of dependency arrays in `createEffect` and `createMemo`. |
@@ -226,8 +232,10 @@ version-aware rule behavior, and enable the 2.0 rules (`solid/removed-api`,
 |  |  | [solid/prefer-structured-class](/packages/eslint-plugin-solid/docs/prefer-structured-class.md) | Enforce using the structured array/object forms of the `class` prop over manually-built class strings. |
 | ✔ |  | [solid/reactivity](/packages/eslint-plugin-solid/docs/reactivity.md) | Enforce that reactivity (props, signals, memos, etc.) is properly used, so changes in those values will be tracked and update the view as expected. |
 |  | 🔧 | [solid/removed-api](/packages/eslint-plugin-solid/docs/removed-api.md) | Disallow Solid 1.x APIs that were removed or renamed in Solid 2.0, with migration guidance. |
+|  | 🔧 | [solid/require-async-server-function](/packages/eslint-plugin-solid/docs/require-async-server-function.md) | Require server functions to be async, matching their client-side contract. |
 | ✔ | 🔧 | [solid/self-closing-comp](/packages/eslint-plugin-solid/docs/self-closing-comp.md) | Disallow extra closing tags for components without children. |
 | ✔ | 🔧 | [solid/style-prop](/packages/eslint-plugin-solid/docs/style-prop.md) | Require CSS properties in the `style` prop to be valid and kebab-cased (ex. 'font-size'), not camel-cased (ex. 'fontSize') like in React, and that property values with dimensions are strings, not numbers with implicit 'px' units. |
+|  |  | [solid/valid-use-server](/packages/eslint-plugin-solid/docs/valid-use-server.md) | Enforce that "use server" directives are placed where the compiler honors them, and that module-level directive files export working server functions. |
 <!-- end-doc-gen -->
 
 ## Troubleshooting

--- a/packages/eslint-plugin-solid/README.md
+++ b/packages/eslint-plugin-solid/README.md
@@ -265,7 +265,7 @@ If you want to pin a minor version, use a tilde in your `package.json`.
 
 <!-- doc-gen TILDE -->
 ```diff
-- "eslint-plugin-solid": "^0.16.1"
-+ "eslint-plugin-solid": "~0.16.1"
+- "eslint-plugin-solid": "^0.17.0"
++ "eslint-plugin-solid": "~0.17.0"
 ```
 <!-- end-doc-gen -->

--- a/packages/eslint-plugin-solid/docs/no-browser-globals-in-server-function.md
+++ b/packages/eslint-plugin-solid/docs/no-browser-globals-in-server-function.md
@@ -1,0 +1,100 @@
+<!-- doc-gen HEADER -->
+# solid/no-browser-globals-in-server-function
+Disallow browser-only globals inside server functions, which run exclusively on the server.
+This rule is **off** by default.
+
+[View source](../src/rules/no-browser-globals-in-server-function.ts) · [View tests](../test/rules/no-browser-globals-in-server-function.test.ts)
+<!-- end-doc-gen -->
+
+Server functions only ever execute on the server, where browser globals like `window`, `document`, and `localStorage` do not exist — referencing them throws at request time. This mistake is easy to make because server functions are written inline next to client code, and easy for AI-generated code to make because the surrounding component uses those globals legitimately.
+
+The rule checks the body of every server function (and every reference in a module-level `"use server"` file) for unambiguous browser-only globals: `window`, `document`, `alert`, `confirm`, `prompt`, `localStorage`, `sessionStorage`, `history`, `location`, `matchMedia`, `getComputedStyle`, `requestAnimationFrame`, `cancelAnimationFrame`, and `customElements`.
+
+The list is deliberately conservative. Server runtimes (Node, Deno, Bun, edge workers) provide much of the web platform — `fetch`, `Response`, `FormData`, `URL`, `crypto`, and even `navigator` — so those are never flagged. Shadowing bindings (a parameter named `document`) and `typeof window` guards are also ignored.
+
+To act on client state in a server function, pass it as an argument; arguments are serialized across the network on every call.
+
+<!-- doc-gen OPTIONS -->
+<!-- end-doc-gen -->
+
+<!-- doc-gen CASES -->
+## Tests
+
+### Invalid Examples
+
+These snippets cause lint errors.
+
+```js
+export async function saveDraft(text) {
+  "use server";
+  localStorage.setItem("draft", text);
+  return db.save(text);
+}
+
+export async function getOrigin() {
+  "use server";
+  return window.location.origin;
+}
+
+export async function renderTitles(ids) {
+  "use server";
+  return ids.map((id) => document.getElementById(id).textContent);
+}
+
+"use server";
+export async function getTheme() {
+  return document.body.dataset.theme;
+}
+
+"use server";
+const width = matchMedia("(min-width: 600px)");
+export async function isWide() {
+  return width.matches;
+}
+
+```
+
+### Valid Examples
+
+These snippets don't cause lint errors.
+
+```js
+export async function getUser(id) {
+  "use server";
+  const res = await fetch("https://api.example.com/users/" + id);
+  const url = new URL(res.url);
+  console.log(crypto.randomUUID(), url.hostname);
+  return res.json();
+}
+
+function Component() {
+  const save = () => localStorage.setItem("draft", "1");
+  return save;
+}
+
+export async function getUser(id) {
+  "use server";
+  if (typeof window !== "undefined") throw new Error("impossible");
+  return db.get(id);
+}
+
+export async function render(document) {
+  "use server";
+  return document.title;
+}
+
+"use server";
+export async function getUser(id) {
+  const res = await fetch("https://api.example.com/users/" + id);
+  return res.json();
+}
+
+const api = {
+  async leak() {
+    "use server";
+    return document.title;
+  },
+};
+
+```
+<!-- end-doc-gen -->

--- a/packages/eslint-plugin-solid/docs/no-invalid-server-capture.md
+++ b/packages/eslint-plugin-solid/docs/no-invalid-server-capture.md
@@ -1,0 +1,133 @@
+<!-- doc-gen HEADER -->
+# solid/no-invalid-server-capture
+Disallow server functions from capturing variables in enclosing non-module scopes, mirroring the compiler's build-time validation.
+This rule is **off** by default.
+
+[View source](../src/rules/no-invalid-server-capture.ts) · [View tests](../test/rules/no-invalid-server-capture.test.ts)
+<!-- end-doc-gen -->
+
+An extracted server function runs in a different closure environment than the one it was written in. On the server it is hoisted to module top level; on the client it is replaced by a network proxy. Either way, a variable captured from an *intermediate* scope — anything declared between module top level and the server function itself, like component state or an enclosing function's parameters — does not exist where the function actually runs.
+
+The Solid compiler rejects these captures at build time. This rule reports the same captures as you type, so the feedback arrives in the editor at the moment the capture is written rather than minutes later in a failed build.
+
+Server functions may freely reference:
+
+- their own parameters and local variables,
+- module top-level bindings and imports,
+- globals,
+- their own name (for named function expressions), and
+- TypeScript types from any scope, since type references are erased from the output.
+
+To pass request-specific data into a server function, use parameters — they are serialized across the network on every call.
+
+The rule mirrors the compiler's scope: module-level `"use server"` files are unaffected (the whole module runs on the server with its closures intact), functions the compiler never extracts (object and class methods) are not validated, and directives nested inside an already-extracted server function are ignored.
+
+<!-- doc-gen OPTIONS -->
+<!-- end-doc-gen -->
+
+<!-- doc-gen CASES -->
+## Tests
+
+### Invalid Examples
+
+These snippets cause lint errors.
+
+```js
+function Component() {
+  const [count, setCount] = createSignal(0);
+  const save = async () => {
+    "use server";
+    return db.save(count());
+  };
+  return save;
+}
+
+function makeGetter(table) {
+  return async (id) => {
+    "use server";
+    return db.get(table, id);
+  };
+}
+
+if (DEV) {
+  const label = "dev";
+  window.save = async () => {
+    "use server";
+    return db.save(label);
+  };
+}
+
+function Component(props) {
+  const upload = async (files) => {
+    "use server";
+    return Promise.all(files.map((file) => db.store(props.bucket, file)));
+  };
+  return upload;
+}
+
+```
+
+### Valid Examples
+
+These snippets don't cause lint errors.
+
+```js
+import { db } from "./db";
+const TABLE = "users";
+export async function getUser(id) {
+  "use server";
+  const key = TABLE + ":" + id;
+  const cached = await cache.get(key);
+  return cached || db.get(TABLE, id);
+}
+
+function Component(props) {
+  const [count, setCount] = createSignal(0);
+  const increment = () => setCount(count() + 1);
+  return increment;
+}
+
+export const fact = async function self(n) {
+  "use server";
+  return n <= 1 ? 1 : n * (await self(n - 1));
+};
+
+"use server";
+export function makeCounter() {
+  let count = 0;
+  return async () => ++count;
+}
+
+function Component() {
+  const secret = 1;
+  const api = {
+    async leak() {
+      "use server";
+      return secret;
+    },
+  };
+  return api;
+}
+
+export async function outer(id) {
+  "use server";
+  const rows = await db.get(id);
+  const pick = async () => {
+    "use server";
+    return rows[0];
+  };
+  return pick();
+}
+
+function makeApi() {
+  interface User {
+    name: string;
+  }
+  return async (raw: unknown) => {
+    "use server";
+    return raw as User;
+  };
+}
+
+```
+<!-- end-doc-gen -->

--- a/packages/eslint-plugin-solid/docs/require-async-server-function.md
+++ b/packages/eslint-plugin-solid/docs/require-async-server-function.md
@@ -1,0 +1,141 @@
+<!-- doc-gen HEADER -->
+# solid/require-async-server-function
+Require server functions to be async, matching their client-side contract.
+This rule is **off** by default.
+
+[View source](../src/rules/require-async-server-function.ts) · [View tests](../test/rules/require-async-server-function.test.ts)
+<!-- end-doc-gen -->
+
+A server function's client half is always asynchronous — every call crosses the network and resolves a `Promise`. The server half deliberately preserves synchronous entry so in-process SSR calls stay fast. That means a non-`async` server function returns `T` during server rendering but `Promise<T>` on the client, and its declared TypeScript type is only right in one of those environments. TypeScript can't catch this: it types the source declaration, not the compiled client proxy.
+
+Making the function `async` gives both environments the same contract, which is why this rule reports every non-`async` server function and autofixes by inserting `async`.
+
+The rule covers both directive forms: functions with their own `"use server"` directive, and every export of a module-level `"use server"` file — including `export { name }` specifiers that resolve to top-level function declarations. Non-exported helpers in a module-level file are left alone; they only ever run in-process on the server, where synchronous returns are meaningful.
+
+<!-- doc-gen OPTIONS -->
+<!-- end-doc-gen -->
+
+<!-- doc-gen CASES -->
+## Tests
+
+### Invalid Examples
+
+These snippets cause lint errors, and all of them can be auto-fixed.
+
+```js
+export const getUser = (id) => {
+  "use server";
+  return db.get(id);
+};
+// after eslint --fix:
+export const getUser = async (id) => {
+  "use server";
+  return db.get(id);
+};
+
+export function getUser(id) {
+  "use server";
+  return db.get(id);
+}
+// after eslint --fix:
+export async function getUser(id) {
+  "use server";
+  return db.get(id);
+}
+
+"use server";
+export function getUser(id) {
+  return db.get(id);
+}
+// after eslint --fix:
+"use server";
+export async function getUser(id) {
+  return db.get(id);
+}
+
+"use server";
+export const listUsers = () => db.all();
+// after eslint --fix:
+"use server";
+export const listUsers = async () => db.all();
+
+"use server";
+function getUser(id) {
+  return db.get(id);
+}
+export { getUser };
+// after eslint --fix:
+"use server";
+async function getUser(id) {
+  return db.get(id);
+}
+export { getUser };
+
+"use server";
+export default function getUser(id) {
+  return db.get(id);
+}
+// after eslint --fix:
+"use server";
+export default async function getUser(id) {
+  return db.get(id);
+}
+
+```
+
+### Valid Examples
+
+These snippets don't cause lint errors.
+
+```js
+export const getUser = async (id) => {
+  "use server";
+  return db.get(id);
+};
+
+export async function getUser(id) {
+  "use server";
+  return db.get(id);
+}
+
+export async function* streamUsers() {
+  "use server";
+  yield* db.stream();
+}
+
+export function totalPrice(items) {
+  return items.reduce((sum, item) => sum + item.price, 0);
+}
+
+const api = {
+  getUser(id) {
+    "use server";
+    return db.get(id);
+  },
+};
+
+"use server";
+export async function getUser(id) {
+  return db.get(id);
+}
+export const listUsers = async () => db.all();
+
+"use server";
+function normalize(user) {
+  return { ...user, name: user.name.trim() };
+}
+export async function getUser(id) {
+  return normalize(await db.get(id));
+}
+
+export async function outer() {
+  "use server";
+  const inner = () => {
+    "use server";
+    return 1;
+  };
+  return inner();
+}
+
+```
+<!-- end-doc-gen -->

--- a/packages/eslint-plugin-solid/docs/valid-use-server.md
+++ b/packages/eslint-plugin-solid/docs/valid-use-server.md
@@ -1,0 +1,184 @@
+<!-- doc-gen HEADER -->
+# solid/valid-use-server
+Enforce that "use server" directives are placed where the compiler honors them, and that module-level directive files export working server functions.
+This rule is **off** by default.
+
+[View source](../src/rules/valid-use-server.ts) · [View tests](../test/rules/valid-use-server.test.ts)
+<!-- end-doc-gen -->
+
+Solid 2.0 makes server functions part of core: a function whose body begins with the `"use server"` directive is extracted to run only on the server, and client calls to it become network requests. The compiler only honors the directive in specific positions, and when it doesn't, the code silently stays on the client — often shipping database access or secrets to the browser without any error.
+
+This rule catches the placement mistakes the compiler ignores silently:
+
+- **Misplaced directives.** `"use server"` is only a directive as part of the directive prologue — the string statements at the very top of a function body or module. After any other statement, or inside an `if`/`for` block, it's an ordinary expression that does nothing.
+- **Template literals.** `` `use server` `` is never a directive; only plain string literals are.
+- **Ineligible positions.** The compiler never extracts object-literal methods, getters, setters, or class methods, so directives inside them are silently ignored. Standalone functions, function-valued properties (`{ getUser: async () => { ... } }`), and block-bodied arrows all work.
+
+It also validates module-level `"use server"` files, where every export is registered as a server function:
+
+- **Non-function exports.** Exporting a constant from a directive module fails at server boot, since the export's value is registered as a callable server function.
+- **Client wrapper calls.** Declaration wrappers like `GET`, `live`, and `withMeta` from `@solidjs/web`, or `query`, `action`, and `liveQuery` from `@solidjs/router`, add behavior in the *client* bundle. In a module-level directive file the client build replaces every export with a bare server reference, so the wrapper never runs on the client: `GET` calls silently go over POST, router caching and submission tracking never happen. Wrap the imported server function in a shared (non-directive) module instead, or use a function-level directive inside the wrapper call.
+
+<!-- doc-gen OPTIONS -->
+## Rule Options
+
+Options shown here are the defaults. Manually configuring an array will *replace* the defaults.
+
+```js
+{
+  "solid/valid-use-server": ["off", { 
+    // Additional function names treated as client-side declaration wrappers that must not be called inside a module-level "use server" file. Supports exact names, '*' wildcards, and regexes given as '/pattern/' strings. GET, live, withMeta, query, action, and liveQuery are always included.
+    clientWrappers: [], // Array<string>
+  }]
+}
+```
+<!-- end-doc-gen -->
+
+The `clientWrappers` option adds project-specific wrapper names (with `*` wildcards or `/regex/` strings) to the built-in list.
+
+<!-- doc-gen CASES -->
+## Tests
+
+### Invalid Examples
+
+These snippets cause lint errors.
+
+```js
+async function getUser(id) {
+  const table = "users";
+  ("use server");
+  return db.get(table, id);
+}
+
+async function getUser(id) {
+  if (id) {
+    ("use server");
+    return db.get(id);
+  }
+}
+
+async function getUser(id) {
+  `use server`;
+  return db.get(id);
+}
+
+`use server`;
+export async function getUser(id) {
+  return db.get(id);
+}
+
+const api = {
+  async getUser(id) {
+    "use server";
+    return db.get(id);
+  },
+};
+
+const api = {
+  get user() {
+    "use server";
+    return db.get(1);
+  },
+};
+
+class Api {
+  async getUser(id) {
+    "use server";
+    return db.get(id);
+  }
+}
+
+"use server";
+export const LIMIT = 10;
+export async function getUsers() {
+  return db.all();
+}
+
+"use server";
+export default { version: 1 };
+
+"use server";
+import { query } from "@solidjs/router";
+export const getUser = query(async (id) => db.get(id), "user");
+
+"use server";
+import { GET } from "@solidjs/web";
+export const listUsers = GET(async () => db.all());
+
+"use server";
+import { action } from "@solidjs/router";
+export const save = action(async (data) => db.save(data));
+
+/* eslint solid/valid-use-server: ["error", { "clientWrappers": ["define*"] }] */
+"use server";
+export const getUser = defineLoader(async (id) => db.get(id));
+
+```
+
+### Valid Examples
+
+These snippets don't cause lint errors.
+
+```js
+export const getUser = async (id) => {
+  "use server";
+  return db.get(id);
+};
+
+export async function getUser(id) {
+  "use server";
+  return db.get(id);
+}
+
+async function getUser(id) {
+  "use strict";
+  "use server";
+  return db.get(id);
+}
+
+const api = {
+  getUser: async function (id) {
+    "use server";
+    return db.get(id);
+  },
+};
+
+const mode = "use server";
+function describe() {
+  return "use server";
+}
+
+"use server";
+export async function getUser(id) {
+  return db.get(id);
+}
+export const listUsers = async () => db.all();
+
+import { query } from "@solidjs/router";
+export const getUser = query(async (id) => {
+  "use server";
+  return db.get(id);
+}, "user");
+
+"use server";
+import { query } from "@solidjs/router";
+export async function setup() {
+  return query(async (id) => db.get(id), "user");
+}
+
+"use server";
+export { helper } from "./helpers";
+
+export async function outer() {
+  "use server";
+  const helpers = {
+    inner() {
+      "use server";
+      return 1;
+    },
+  };
+  return helpers.inner();
+}
+
+```
+<!-- end-doc-gen -->

--- a/packages/eslint-plugin-solid/package.json
+++ b/packages/eslint-plugin-solid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-solid",
-  "version": "0.16.1",
+  "version": "0.17.0",
   "description": "Solid-specific linting rules for ESLint.",
   "keywords": [
     "eslint",

--- a/packages/eslint-plugin-solid/src/configs/v2.ts
+++ b/packages/eslint-plugin-solid/src/configs/v2.ts
@@ -38,6 +38,15 @@ const v2 = {
     "solid/event-handlers": 2,
     // className/htmlFor pass through as literal attributes the DOM ignores
     "solid/no-react-specific-props": 2,
+    // server functions are core in 2.0; misplaced/ignored "use server"
+    // directives and broken module-level directive files are silent failures
+    "solid/valid-use-server": 2,
+    // a sync server function returns T during SSR but Promise<T> on the client
+    "solid/require-async-server-function": 2,
+    // editor-time mirror of the compiler's closure-capture validation
+    "solid/no-invalid-server-capture": 2,
+    // server functions never run where browser globals exist
+    "solid/no-browser-globals-in-server-function": 2,
     // premise no longer exists in 2.0 (rule also self-gates on version)
     "solid/no-react-deps": 0,
     // anti-advice in 2.0: classList was removed in favor of class objects/arrays

--- a/packages/eslint-plugin-solid/src/plugin.ts
+++ b/packages/eslint-plugin-solid/src/plugin.ts
@@ -14,8 +14,10 @@ import jsxNoScriptUrl from "./rules/jsx-no-script-url";
 import jsxNoUndef from "./rules/jsx-no-undef";
 import jsxUsesVars from "./rules/jsx-uses-vars";
 import noAccessorAsProp from "./rules/no-accessor-as-prop";
+import noBrowserGlobalsInServerFunction from "./rules/no-browser-globals-in-server-function";
 import noDestructure from "./rules/no-destructure";
 import noInnerHTML from "./rules/no-innerhtml";
+import noInvalidServerCapture from "./rules/no-invalid-server-capture";
 import noModuleScopeReactivePrimitive from "./rules/no-module-scope-reactive-primitive";
 import noProxyApis from "./rules/no-proxy-apis";
 import noReactDeps from "./rules/no-react-deps";
@@ -30,8 +32,10 @@ import preferShow from "./rules/prefer-show";
 import preferStructuredClass from "./rules/prefer-structured-class";
 import reactivity from "./rules/reactivity";
 import removedApi from "./rules/removed-api";
+import requireAsyncServerFunction from "./rules/require-async-server-function";
 import selfClosingComp from "./rules/self-closing-comp";
 import styleProp from "./rules/style-prop";
+import validUseServer from "./rules/valid-use-server";
 import noArrayHandlers from "./rules/no-array-handlers";
 // import validateJsxNesting from "./rules/validate-jsx-nesting";
 
@@ -49,8 +53,10 @@ const allRules = {
   "jsx-no-script-url": jsxNoScriptUrl,
   "jsx-uses-vars": jsxUsesVars,
   "no-accessor-as-prop": noAccessorAsProp,
+  "no-browser-globals-in-server-function": noBrowserGlobalsInServerFunction,
   "no-destructure": noDestructure,
   "no-innerhtml": noInnerHTML,
+  "no-invalid-server-capture": noInvalidServerCapture,
   "no-module-scope-reactive-primitive": noModuleScopeReactivePrimitive,
   "no-proxy-apis": noProxyApis,
   "no-react-deps": noReactDeps,
@@ -65,8 +71,10 @@ const allRules = {
   "prefer-structured-class": preferStructuredClass,
   reactivity,
   "removed-api": removedApi,
+  "require-async-server-function": requireAsyncServerFunction,
   "self-closing-comp": selfClosingComp,
   "style-prop": styleProp,
+  "valid-use-server": validUseServer,
   "no-array-handlers": noArrayHandlers,
   // "validate-jsx-nesting": validateJsxNesting
 };

--- a/packages/eslint-plugin-solid/src/rules/no-browser-globals-in-server-function.ts
+++ b/packages/eslint-plugin-solid/src/rules/no-browser-globals-in-server-function.ts
@@ -1,0 +1,108 @@
+/**
+ * FIXME: remove this comments and import when below issue is fixed.
+ * This import is necessary for type generation due to a bug in the TypeScript compiler.
+ * See: https://github.com/microsoft/TypeScript/issues/42873
+ */
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+import type { TSESLint } from "@typescript-eslint/utils";
+
+import { TSESTree as T, TSESLint as Lint, ESLintUtils } from "@typescript-eslint/utils";
+import {
+  isFunctionNode,
+  hasUseServerDirective,
+  getUseServerEligibility,
+  isInsideUseServerFunction,
+  programHasUseServerDirective,
+} from "../utils";
+import { getSourceCode } from "../compat";
+
+const createRule = ESLintUtils.RuleCreator.withoutDocs;
+
+type MessageIds = "browserGlobal";
+type Options = [];
+
+/**
+ * Globals that exist only in browsers. Deliberately conservative: server
+ * runtimes (Node, Deno, Bun, edge workers) provide `fetch`, `Response`,
+ * `FormData`, `URL`, `crypto`, and even `navigator`, so only unambiguous
+ * DOM/BOM globals are listed.
+ */
+const BROWSER_GLOBALS = new Set([
+  "window",
+  "document",
+  "alert",
+  "confirm",
+  "prompt",
+  "localStorage",
+  "sessionStorage",
+  "history",
+  "location",
+  "matchMedia",
+  "getComputedStyle",
+  "requestAnimationFrame",
+  "cancelAnimationFrame",
+  "customElements",
+]);
+
+export default createRule<Options, MessageIds>({
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "Disallow browser-only globals inside server functions, which run exclusively on the server.",
+      url: "https://github.com/solidjs-community/eslint-plugin-solid/blob/main/packages/eslint-plugin-solid/docs/no-browser-globals-in-server-function.md",
+    },
+    schema: [],
+    messages: {
+      browserGlobal:
+        "'{{name}}' is a browser global, and server functions only run on the server, where it does not exist. Read request data from the function's arguments or use server platform APIs instead.",
+    },
+  },
+  defaultOptions: [],
+  create(context) {
+    const sourceCode = getSourceCode(context);
+    let moduleLevel = false;
+
+    const checkReferences = (references: Lint.Scope.Reference[]) => {
+      for (const reference of references) {
+        const name = reference.identifier.name;
+        if (!BROWSER_GLOBALS.has(name)) continue;
+        // A binding with definitions is the user's own variable; a def-less
+        // resolution is a configured global (e.g. `globals.browser`).
+        if (reference.resolved && reference.resolved.defs.length > 0) continue;
+        // `typeof window` guards are dead code here but intentional
+        const parent = reference.identifier.parent;
+        if (parent?.type === "UnaryExpression" && parent.operator === "typeof") continue;
+        context.report({
+          node: reference.identifier,
+          messageId: "browserGlobal",
+          data: { name },
+        });
+      }
+    };
+
+    return {
+      Program(node) {
+        moduleLevel = programHasUseServerDirective(node);
+        if (moduleLevel) {
+          // The whole module runs on the server; check every reference in it.
+          // References resolved to configured globals (`globals.browser`)
+          // never reach a scope's `through`, so walk each scope directly.
+          for (const scope of sourceCode.scopeManager?.scopes ?? []) {
+            checkReferences(scope.references);
+          }
+        }
+      },
+      ":function"(node: T.Node) {
+        if (moduleLevel || !isFunctionNode(node)) return;
+        if (!hasUseServerDirective(node)) return;
+        if (getUseServerEligibility(node) !== "eligible") return;
+        if (isInsideUseServerFunction(node)) return;
+        const scope = sourceCode.scopeManager?.acquire(node);
+        // `through` holds every reference crossing the function's boundary,
+        // including refs from nested scopes that resolve to outer globals.
+        if (scope) checkReferences(scope.through);
+      },
+    };
+  },
+});

--- a/packages/eslint-plugin-solid/src/rules/no-invalid-server-capture.ts
+++ b/packages/eslint-plugin-solid/src/rules/no-invalid-server-capture.ts
@@ -1,0 +1,104 @@
+/**
+ * FIXME: remove this comments and import when below issue is fixed.
+ * This import is necessary for type generation due to a bug in the TypeScript compiler.
+ * See: https://github.com/microsoft/TypeScript/issues/42873
+ */
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+import type { TSESLint } from "@typescript-eslint/utils";
+
+import { TSESTree as T, ESLintUtils } from "@typescript-eslint/utils";
+import {
+  isFunctionNode,
+  hasUseServerDirective,
+  getUseServerEligibility,
+  isInsideUseServerFunction,
+  programHasUseServerDirective,
+} from "../utils";
+import { getSourceCode } from "../compat";
+
+const createRule = ESLintUtils.RuleCreator.withoutDocs;
+
+type MessageIds = "invalidCapture";
+type Options = [];
+
+/*
+ * An editor-time mirror of the compiler's closure-capture validation. An
+ * extracted server function runs in a different closure environment than the
+ * one it was written in: on the server it is hoisted to module top level, on
+ * the client it is replaced by a network proxy. Any variable captured from an
+ * intermediate scope — declared between module top level and the server
+ * function itself — does not exist at runtime. The compiler rejects this at
+ * build time; this rule reports the same captures as you type.
+ *
+ * Module-level directives are unaffected (the whole module runs on the
+ * server, so its closures are intact). Eligibility mirrors the transform:
+ * functions it never extracts (object/class methods, getters/setters) are
+ * not validated, and directives nested inside an already-extracted server
+ * function are ignored.
+ */
+export default createRule<Options, MessageIds>({
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "Disallow server functions from capturing variables in enclosing non-module scopes, mirroring the compiler's build-time validation.",
+      url: "https://github.com/solidjs-community/eslint-plugin-solid/blob/main/packages/eslint-plugin-solid/docs/no-invalid-server-capture.md",
+    },
+    schema: [],
+    messages: {
+      invalidCapture:
+        "Server functions cannot capture '{{name}}' from an enclosing {{kind}}: on the server the function is hoisted to module level and on the client it becomes a network proxy, so the captured variable does not exist at runtime. Use parameters, module-level bindings, imports, or globals instead.",
+    },
+  },
+  defaultOptions: [],
+  create(context) {
+    const sourceCode = getSourceCode(context);
+    let moduleLevel = false;
+
+    return {
+      Program(node) {
+        moduleLevel = programHasUseServerDirective(node);
+      },
+      ":function"(node: T.Node) {
+        if (!isFunctionNode(node)) return;
+        if (moduleLevel) return;
+        if (!hasUseServerDirective(node)) return;
+        if (getUseServerEligibility(node) !== "eligible") return;
+        if (isInsideUseServerFunction(node)) return;
+
+        const scope = sourceCode.scopeManager?.acquire(node);
+        if (!scope) return;
+        // `through` holds every reference crossing this function's boundary,
+        // including those from nested scopes.
+        for (const reference of scope.through) {
+          const variable = reference.resolved;
+          if (!variable) continue; // a true global
+          // TS type-only references are erased from the output and never captured
+          const typedReference = reference as {
+            isTypeReference?: boolean;
+            isValueReference?: boolean;
+          };
+          if (typedReference.isTypeReference && !typedReference.isValueReference) continue;
+          const declarationScope = variable.scope;
+          if (declarationScope.type === "module" || declarationScope.type === "global") continue;
+          // A named function expression referencing itself travels with the
+          // extracted function and stays valid.
+          if (
+            declarationScope.type === "function-expression-name" &&
+            declarationScope.block === node
+          ) {
+            continue;
+          }
+          context.report({
+            node: reference.identifier,
+            messageId: "invalidCapture",
+            data: {
+              name: reference.identifier.name,
+              kind: declarationScope.type === "function" ? "function" : "block",
+            },
+          });
+        }
+      },
+    };
+  },
+});

--- a/packages/eslint-plugin-solid/src/rules/reactivity.ts
+++ b/packages/eslint-plugin-solid/src/rules/reactivity.ts
@@ -20,6 +20,7 @@ import {
   isJSXElementOrFragment,
   isSolidV2,
   trace,
+  createNameMatcher,
 } from "../utils";
 import { findVariable, getScope, CompatContext, getSourceCode } from "../compat";
 
@@ -325,31 +326,9 @@ export default createRule<Options, MessageIds>({
 
     /**
      * `customReactiveFunctions` entries may be exact names, glob-ish patterns using `*`
-     * wildcards, or regexes written as "/pattern/" strings. Compile them once.
+     * wildcards, or regexes written as "/pattern/" strings.
      */
-    const customReactiveMatchers: (string | RegExp)[] = options.customReactiveFunctions.map(
-      (entry) => {
-        if (entry.length > 2 && entry.startsWith("/") && entry.endsWith("/")) {
-          try {
-            return new RegExp(entry.slice(1, -1));
-          } catch {
-            return entry;
-          }
-        }
-        if (entry.includes("*")) {
-          const escaped = entry
-            .split("*")
-            .map((part) => part.replace(/[.+?^${}()|[\]\\]/g, "\\$&"))
-            .join("[a-zA-Z0-9_$]*");
-          return new RegExp(`^${escaped}$`);
-        }
-        return entry;
-      }
-    );
-    const matchesCustomReactive = (name: string): boolean =>
-      customReactiveMatchers.some((matcher) =>
-        typeof matcher === "string" ? matcher === name : matcher.test(name)
-      );
+    const matchesCustomReactive = createNameMatcher(options.customReactiveFunctions);
 
     /**
      * JSXExpressionContainers for `value={...}` props on context providers. Providers read

--- a/packages/eslint-plugin-solid/src/rules/require-async-server-function.ts
+++ b/packages/eslint-plugin-solid/src/rules/require-async-server-function.ts
@@ -1,0 +1,122 @@
+/**
+ * FIXME: remove this comments and import when below issue is fixed.
+ * This import is necessary for type generation due to a bug in the TypeScript compiler.
+ * See: https://github.com/microsoft/TypeScript/issues/42873
+ */
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+import type { TSESLint } from "@typescript-eslint/utils";
+
+import { TSESTree as T, ESLintUtils, ASTUtils } from "@typescript-eslint/utils";
+import {
+  FunctionNode,
+  isFunctionNode,
+  hasUseServerDirective,
+  getUseServerEligibility,
+  isInsideUseServerFunction,
+  programHasUseServerDirective,
+} from "../utils";
+import { findVariable, getSourceCode } from "../compat";
+
+const { getFunctionHeadLocation } = ASTUtils;
+const createRule = ESLintUtils.RuleCreator.withoutDocs;
+
+type MessageIds = "asyncServerFunction";
+type Options = [];
+
+/*
+ * The client half of a server function is always asynchronous: calls cross
+ * the network and resolve a Promise. The server half deliberately preserves
+ * synchronous entry for in-process SSR calls. A non-async server function
+ * therefore returns `T` during SSR and `Promise<T>` on the client, and its
+ * declared TypeScript type matches only one of them — a split TS cannot see,
+ * because it types the source declaration, not the compiled proxy.
+ */
+export default createRule<Options, MessageIds>({
+  meta: {
+    type: "problem",
+    docs: {
+      description: "Require server functions to be async, matching their client-side contract.",
+      url: "https://github.com/solidjs-community/eslint-plugin-solid/blob/main/packages/eslint-plugin-solid/docs/require-async-server-function.md",
+    },
+    fixable: "code",
+    schema: [],
+    messages: {
+      asyncServerFunction:
+        "Server functions should be async: on the client every call resolves a Promise, but during server rendering this function is called in-process and returns synchronously, so the same code observes two different types.",
+    },
+  },
+  defaultOptions: [],
+  create(context) {
+    const sourceCode = getSourceCode(context);
+    let moduleLevel = false;
+
+    const checkFunction = (fn: FunctionNode) => {
+      if (fn.async) return;
+      context.report({
+        loc: getFunctionHeadLocation(fn, sourceCode),
+        messageId: "asyncServerFunction",
+        fix: (fixer) => {
+          const firstToken = sourceCode.getFirstToken(fn);
+          return firstToken ? fixer.insertTextBefore(firstToken, "async ") : null;
+        },
+      });
+    };
+
+    /** Resolves `export { name }` specifiers to top-level function nodes. */
+    const resolveExportedFunction = (identifier: T.Identifier): FunctionNode | null => {
+      const variable = findVariable(context, identifier);
+      const def = variable?.defs[0];
+      if (!def) return null;
+      if (def.type === "FunctionName" && isFunctionNode(def.node)) return def.node;
+      if (
+        def.type === "Variable" &&
+        def.node.type === "VariableDeclarator" &&
+        isFunctionNode(def.node.init)
+      ) {
+        return def.node.init;
+      }
+      return null;
+    };
+
+    return {
+      Program(node) {
+        moduleLevel = programHasUseServerDirective(node);
+      },
+      ":function"(node: T.Node) {
+        if (!isFunctionNode(node)) return;
+        // Function-level directives. Ineligible positions (object/class
+        // methods) are never extracted at all; valid-use-server owns those.
+        if (
+          !moduleLevel &&
+          hasUseServerDirective(node) &&
+          getUseServerEligibility(node) === "eligible" &&
+          !isInsideUseServerFunction(node)
+        ) {
+          checkFunction(node);
+        }
+      },
+      ExportNamedDeclaration(node) {
+        if (!moduleLevel) return;
+        if (node.declaration) {
+          if (isFunctionNode(node.declaration)) {
+            checkFunction(node.declaration);
+          } else if (node.declaration.type === "VariableDeclaration") {
+            for (const declarator of node.declaration.declarations) {
+              if (isFunctionNode(declarator.init)) checkFunction(declarator.init);
+            }
+          }
+        } else {
+          for (const specifier of node.specifiers) {
+            if (specifier.local.type !== "Identifier") continue;
+            const fn = resolveExportedFunction(specifier.local);
+            if (fn) checkFunction(fn);
+          }
+        }
+      },
+      ExportDefaultDeclaration(node) {
+        if (!moduleLevel) return;
+        if (isFunctionNode(node.declaration)) checkFunction(node.declaration);
+      },
+    };
+  },
+});

--- a/packages/eslint-plugin-solid/src/rules/valid-use-server.ts
+++ b/packages/eslint-plugin-solid/src/rules/valid-use-server.ts
@@ -1,0 +1,192 @@
+/**
+ * FIXME: remove this comments and import when below issue is fixed.
+ * This import is necessary for type generation due to a bug in the TypeScript compiler.
+ * See: https://github.com/microsoft/TypeScript/issues/42873
+ */
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+import type { TSESLint } from "@typescript-eslint/utils";
+
+import { TSESTree as T, ESLintUtils } from "@typescript-eslint/utils";
+import {
+  findParent,
+  isFunctionNode,
+  trackImports,
+  createNameMatcher,
+  getDirectivePrologue,
+  getUseServerEligibility,
+  isInsideUseServerFunction,
+  programHasUseServerDirective,
+} from "../utils";
+
+const createRule = ESLintUtils.RuleCreator.withoutDocs;
+
+type MessageIds =
+  | "misplacedDirective"
+  | "templateDirective"
+  | "ineligiblePosition"
+  | "nonFunctionExport"
+  | "clientWrapper";
+type Options = [{ clientWrappers: string[] }];
+
+const POSITION_LABELS = {
+  objectMethod: "an object method",
+  accessor: "a getter or setter",
+  classMethod: "a class method",
+} as const;
+
+/**
+ * Declaration wrappers whose behavior lives in the client bundle. In a
+ * module-level "use server" file the client build replaces every export with
+ * a bare server reference, so these wrapper calls are compiled out of the
+ * client entirely: `GET`/`withMeta` metadata never reaches the client proxy
+ * (calls silently go over POST), `live` sources never get their live
+ * transport, and the router's `query`/`action`/`liveQuery` integration
+ * (caching, dedup, submission tracking) never happens.
+ */
+const CLIENT_WRAPPERS = ["GET", "live", "withMeta", "query", "action", "liveQuery"];
+const WRAPPER_SOURCES = /^(?:solid-js|@solidjs\/(?:web|router|start))(?:\/|$)/;
+
+const isDefinitelyNotFunction = (node: T.Node): boolean =>
+  node.type === "Literal" ||
+  node.type === "TemplateLiteral" ||
+  node.type === "ArrayExpression" ||
+  node.type === "ObjectExpression";
+
+export default createRule<Options, MessageIds>({
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        'Enforce that "use server" directives are placed where the compiler honors them, and that module-level directive files export working server functions.',
+      url: "https://github.com/solidjs-community/eslint-plugin-solid/blob/main/packages/eslint-plugin-solid/docs/valid-use-server.md",
+    },
+    schema: [
+      {
+        type: "object",
+        properties: {
+          clientWrappers: {
+            description:
+              "Additional function names treated as client-side declaration wrappers that must not be called inside a module-level \"use server\" file. Supports exact names, '*' wildcards, and regexes given as '/pattern/' strings. GET, live, withMeta, query, action, and liveQuery are always included.",
+            type: "array",
+            items: { type: "string" },
+            default: [],
+          },
+        },
+        additionalProperties: false,
+      },
+    ],
+    messages: {
+      misplacedDirective:
+        'The "use server" directive only takes effect as the first statement of a function body or module; here it is an ordinary expression statement and the code stays on the client.',
+      templateDirective:
+        'A template literal is never a directive; this code stays on the client. Use a plain string: "use server".',
+      ineligiblePosition:
+        'The "use server" directive in {{position}} is silently ignored — the function is never extracted to the server. Use a standalone function, a function-valued property, or a block-bodied arrow instead.',
+      nonFunctionExport:
+        "Every export of a module-level \"use server\" file is registered as a server function; '{{name}}' is not a function and will fail the server at boot. Move non-function exports to another module.",
+      clientWrapper:
+        "In a module-level \"use server\" file the client receives bare server references, so '{{name}}' never runs on the client and its behavior is silently lost. Wrap the imported server function in a shared module instead, or move the directive inside the wrapped function.",
+    },
+  },
+  defaultOptions: [{ clientWrappers: [] }],
+  create(context, [options]) {
+    const { matchImport, handleImportDeclaration } = trackImports(WRAPPER_SOURCES);
+    const matchesCustomWrapper = createNameMatcher(options.clientWrappers);
+    let moduleLevel = false;
+
+    const checkExportedValue = (node: T.Node, name: string) => {
+      if (isDefinitelyNotFunction(node)) {
+        context.report({ node, messageId: "nonFunctionExport", data: { name } });
+      }
+    };
+
+    return {
+      Program(node) {
+        moduleLevel = programHasUseServerDirective(node);
+      },
+      ImportDeclaration: handleImportDeclaration,
+      ExpressionStatement(node) {
+        const { expression } = node;
+        const isTemplate =
+          expression.type === "TemplateLiteral" &&
+          expression.expressions.length === 0 &&
+          expression.quasis.length === 1 &&
+          expression.quasis[0].value.cooked === "use server";
+        const isString = expression.type === "Literal" && expression.value === "use server";
+        if (!isTemplate && !isString) return;
+
+        if (isTemplate) {
+          context.report({ node, messageId: "templateDirective" });
+          return;
+        }
+
+        // In a module-level directive file, or nested inside an extracted
+        // server function, the whole scope already runs on the server —
+        // stray inner directives are ignored by the transform and harmless.
+        if (moduleLevel) return;
+        const nearestFunction = findParent(node, isFunctionNode);
+        if (
+          nearestFunction &&
+          isFunctionNode(nearestFunction) &&
+          isInsideUseServerFunction(nearestFunction)
+        ) {
+          return;
+        }
+
+        const parent = node.parent;
+        const enclosingFunction =
+          parent?.type === "BlockStatement" && isFunctionNode(parent.parent) ? parent.parent : null;
+        if (
+          parent?.type !== "Program" &&
+          (parent?.type !== "BlockStatement" || !enclosingFunction)
+        ) {
+          // A string statement in a plain block (if/for body, bare block):
+          // blocks have no directive prologue.
+          context.report({ node, messageId: "misplacedDirective" });
+          return;
+        }
+
+        const body = parent.body;
+        if (!getDirectivePrologue(body).includes(node)) {
+          context.report({ node, messageId: "misplacedDirective" });
+          return;
+        }
+
+        if (enclosingFunction && !isInsideUseServerFunction(enclosingFunction)) {
+          const eligibility = getUseServerEligibility(enclosingFunction);
+          if (eligibility !== "eligible") {
+            context.report({
+              node,
+              messageId: "ineligiblePosition",
+              data: { position: POSITION_LABELS[eligibility] },
+            });
+          }
+        }
+      },
+      ExportNamedDeclaration(node) {
+        if (!moduleLevel || !node.declaration) return;
+        if (node.declaration.type === "VariableDeclaration") {
+          for (const declarator of node.declaration.declarations) {
+            if (declarator.init && declarator.id.type === "Identifier") {
+              checkExportedValue(declarator.init, declarator.id.name);
+            }
+          }
+        }
+      },
+      ExportDefaultDeclaration(node) {
+        if (!moduleLevel) return;
+        checkExportedValue(node.declaration, "default");
+      },
+      CallExpression(node) {
+        if (!moduleLevel || node.callee.type !== "Identifier") return;
+        // Only module-scope calls: wrapper calls inside functions are just
+        // server-side code, which is the caller's business.
+        if (findParent(node, isFunctionNode) != null) return;
+        const name = node.callee.name;
+        if (matchImport(CLIENT_WRAPPERS, name) || matchesCustomWrapper(name)) {
+          context.report({ node, messageId: "clientWrapper", data: { name } });
+        }
+      },
+    };
+  },
+});

--- a/packages/eslint-plugin-solid/src/utils.ts
+++ b/packages/eslint-plugin-solid/src/utils.ts
@@ -173,6 +173,102 @@ export const getCommentAfter = (
     .getCommentsAfter(node)
     .find((comment) => comment.loc!.start.line === node.loc!.end.line);
 
+/**
+ * The leading string-literal expression statements of a program or function
+ * body — the directive prologue. Only statements here are directives; a
+ * `"use server"` string anywhere else is an ordinary expression.
+ */
+export const getDirectivePrologue = (body: T.Statement[]): T.ExpressionStatement[] => {
+  const prologue: T.ExpressionStatement[] = [];
+  for (const statement of body) {
+    if (
+      statement.type === "ExpressionStatement" &&
+      statement.expression.type === "Literal" &&
+      typeof statement.expression.value === "string"
+    ) {
+      prologue.push(statement);
+    } else {
+      break;
+    }
+  }
+  return prologue;
+};
+
+const prologueHasDirective = (body: T.Statement[], directive: string): boolean =>
+  getDirectivePrologue(body).some(
+    (statement) => (statement.expression as T.StringLiteral).value === directive
+  );
+
+/** Whether a function has a `"use server"` directive in its body's prologue. */
+export const hasUseServerDirective = (fn: FunctionNode): boolean =>
+  fn.body?.type === "BlockStatement" && prologueHasDirective(fn.body.body, "use server");
+
+/** Whether a program has a module-level `"use server"` directive. */
+export const programHasUseServerDirective = (program: T.Program): boolean =>
+  prologueHasDirective(program.body, "use server");
+
+/**
+ * Whether the `"use server"` transform would extract this function. Mirrors
+ * the compiler: object-literal methods, getters/setters, and class methods
+ * are never extracted, so directives inside them are silently ignored.
+ */
+export type UseServerEligibility = "eligible" | "objectMethod" | "accessor" | "classMethod";
+export const getUseServerEligibility = (fn: FunctionNode): UseServerEligibility => {
+  const parent = fn.parent;
+  if (parent?.type === "Property" && parent.value === fn) {
+    if (parent.kind !== "init") return "accessor";
+    if (parent.method) return "objectMethod";
+  }
+  if (parent?.type === "MethodDefinition") {
+    return parent.kind === "get" || parent.kind === "set" ? "accessor" : "classMethod";
+  }
+  return "eligible";
+};
+
+/**
+ * Whether `fn` is nested inside another function carrying a `"use server"`
+ * directive. The transform extracts the outermost marked function only;
+ * directives inside it are ignored (the code already runs on the server).
+ */
+export const isInsideUseServerFunction = (fn: FunctionNode): boolean => {
+  let parent = findParent(fn, isFunctionNode);
+  while (parent) {
+    if (isFunctionNode(parent) && hasUseServerDirective(parent)) return true;
+    parent = findParent(parent, isFunctionNode);
+  }
+  return false;
+};
+
+/**
+ * Compiles a list of user-provided name patterns into a matcher. Entries may
+ * be exact names, glob-ish patterns using `*` wildcards ("watch*"), or
+ * regexes written as "/pattern/" strings. Invalid regexes fall back to exact
+ * string comparison.
+ */
+export const createNameMatcher = (patterns: string[]): ((name: string) => boolean) => {
+  const matchers: (string | RegExp)[] = patterns.map((entry) => {
+    if (entry.length > 2 && entry.startsWith("/") && entry.endsWith("/")) {
+      try {
+        return new RegExp(entry.slice(1, -1));
+      } catch {
+        return entry;
+      }
+    }
+    if (entry.includes("*")) {
+      const escaped = entry
+        .split("*")
+        .map((part) => part.replace(/[.+?^${}()|[\]\\]/g, "\\$&"))
+        .join("[a-zA-Z0-9_$]*");
+      return new RegExp(`^${escaped}$`);
+    }
+    return entry;
+  });
+  return (name: string): boolean =>
+    matchers.some((matcher) =>
+      typeof matcher === "string" ? matcher === name : matcher.test(name)
+    );
+};
+
 // Matches "solid-js", its submodules ("solid-js/store", etc.), and the Solid 2.0
 // "@solidjs/signals" package, which re-exports the core reactive primitives.
 export const trackImports = (

--- a/packages/eslint-plugin-solid/test/rules/no-browser-globals-in-server-function.test.ts
+++ b/packages/eslint-plugin-solid/test/rules/no-browser-globals-in-server-function.test.ts
@@ -1,0 +1,85 @@
+import { run } from "../ruleTester";
+import rule from "../../src/rules/no-browser-globals-in-server-function";
+
+export const cases = run("no-browser-globals-in-server-function", rule, {
+  valid: [
+    // server runtimes provide the web platform APIs that matter
+    `export async function getUser(id) {
+  "use server";
+  const res = await fetch("https://api.example.com/users/" + id);
+  const url = new URL(res.url);
+  console.log(crypto.randomUUID(), url.hostname);
+  return res.json();
+}`,
+    // browser globals are fine outside server functions
+    `function Component() {
+  const save = () => localStorage.setItem("draft", "1");
+  return save;
+}`,
+    // typeof guards are intentional, if pointless, here
+    `export async function getUser(id) {
+  "use server";
+  if (typeof window !== "undefined") throw new Error("impossible");
+  return db.get(id);
+}`,
+    // a shadowing binding is the user's own variable
+    `export async function render(document) {
+  "use server";
+  return document.title;
+}`,
+    // module-level directive file using server-safe APIs
+    `"use server";
+export async function getUser(id) {
+  const res = await fetch("https://api.example.com/users/" + id);
+  return res.json();
+}`,
+    // object/class methods are never extracted; valid-use-server owns those
+    `const api = {
+  async leak() {
+    "use server";
+    return document.title;
+  },
+};`,
+  ],
+  invalid: [
+    {
+      code: `export async function saveDraft(text) {
+  "use server";
+  localStorage.setItem("draft", text);
+  return db.save(text);
+}`,
+      errors: [{ messageId: "browserGlobal", data: { name: "localStorage" } }],
+    },
+    {
+      code: `export async function getOrigin() {
+  "use server";
+  return window.location.origin;
+}`,
+      errors: [{ messageId: "browserGlobal", data: { name: "window" } }],
+    },
+    // references in nested closures inside the server function still count
+    {
+      code: `export async function renderTitles(ids) {
+  "use server";
+  return ids.map((id) => document.getElementById(id).textContent);
+}`,
+      errors: [{ messageId: "browserGlobal", data: { name: "document" } }],
+    },
+    // module-level directive: the whole file runs on the server
+    {
+      code: `"use server";
+export async function getTheme() {
+  return document.body.dataset.theme;
+}`,
+      errors: [{ messageId: "browserGlobal", data: { name: "document" } }],
+    },
+    {
+      code: `"use server";
+const width = matchMedia("(min-width: 600px)");
+export async function isWide() {
+  return width.matches;
+}`,
+      errors: [{ messageId: "browserGlobal", data: { name: "matchMedia" } }],
+    },
+  ],
+});

--- a/packages/eslint-plugin-solid/test/rules/no-invalid-server-capture.test.ts
+++ b/packages/eslint-plugin-solid/test/rules/no-invalid-server-capture.test.ts
@@ -1,0 +1,113 @@
+import { run, tsOnly } from "../ruleTester";
+import rule from "../../src/rules/no-invalid-server-capture";
+
+export const cases = run("no-invalid-server-capture", rule, {
+  valid: [
+    // module top-level bindings, imports, params, locals, and globals are fine
+    `import { db } from "./db";
+const TABLE = "users";
+export async function getUser(id) {
+  "use server";
+  const key = TABLE + ":" + id;
+  const cached = await cache.get(key);
+  return cached || db.get(TABLE, id);
+}`,
+    // functions without a directive can capture anything
+    `function Component(props) {
+  const [count, setCount] = createSignal(0);
+  const increment = () => setCount(count() + 1);
+  return increment;
+}`,
+    // a named function expression may reference itself
+    `export const fact = async function self(n) {
+  "use server";
+  return n <= 1 ? 1 : n * (await self(n - 1));
+};`,
+    // module-level directive files keep their closures intact on the server
+    `"use server";
+export function makeCounter() {
+  let count = 0;
+  return async () => ++count;
+}`,
+    // object/class methods are never extracted; valid-use-server owns those
+    `function Component() {
+  const secret = 1;
+  const api = {
+    async leak() {
+      "use server";
+      return secret;
+    },
+  };
+  return api;
+}`,
+    // directives nested inside a server function are ignored by the transform
+    `export async function outer(id) {
+  "use server";
+  const rows = await db.get(id);
+  const pick = async () => {
+    "use server";
+    return rows[0];
+  };
+  return pick();
+}`,
+    // TS type-only references are erased from the output and never captured
+    {
+      code: `function makeApi() {
+  interface User {
+    name: string;
+  }
+  return async (raw: unknown) => {
+    "use server";
+    return raw as User;
+  };
+}`,
+      [tsOnly]: true,
+    },
+  ],
+  invalid: [
+    // capturing component state
+    {
+      code: `function Component() {
+  const [count, setCount] = createSignal(0);
+  const save = async () => {
+    "use server";
+    return db.save(count());
+  };
+  return save;
+}`,
+      errors: [{ messageId: "invalidCapture", data: { name: "count", kind: "function" } }],
+    },
+    // capturing an enclosing function's parameter
+    {
+      code: `function makeGetter(table) {
+  return async (id) => {
+    "use server";
+    return db.get(table, id);
+  };
+}`,
+      errors: [{ messageId: "invalidCapture", data: { name: "table", kind: "function" } }],
+    },
+    // capturing a block-scoped binding
+    {
+      code: `if (DEV) {
+  const label = "dev";
+  window.save = async () => {
+    "use server";
+    return db.save(label);
+  };
+}`,
+      errors: [{ messageId: "invalidCapture", data: { name: "label", kind: "block" } }],
+    },
+    // captures in nested closures inside the server function still count
+    {
+      code: `function Component(props) {
+  const upload = async (files) => {
+    "use server";
+    return Promise.all(files.map((file) => db.store(props.bucket, file)));
+  };
+  return upload;
+}`,
+      errors: [{ messageId: "invalidCapture", data: { name: "props", kind: "function" } }],
+    },
+  ],
+});

--- a/packages/eslint-plugin-solid/test/rules/require-async-server-function.test.ts
+++ b/packages/eslint-plugin-solid/test/rules/require-async-server-function.test.ts
@@ -1,0 +1,123 @@
+import { run } from "../ruleTester";
+import rule from "../../src/rules/require-async-server-function";
+
+export const cases = run("require-async-server-function", rule, {
+  valid: [
+    // async server functions in every eligible form
+    `export const getUser = async (id) => {
+  "use server";
+  return db.get(id);
+};`,
+    `export async function getUser(id) {
+  "use server";
+  return db.get(id);
+}`,
+    // async generators are async
+    `export async function* streamUsers() {
+  "use server";
+  yield* db.stream();
+}`,
+    // sync functions without a directive are none of this rule's business
+    `export function totalPrice(items) {
+  return items.reduce((sum, item) => sum + item.price, 0);
+}`,
+    // object/class methods are never extracted; valid-use-server owns those
+    `const api = {
+  getUser(id) {
+    "use server";
+    return db.get(id);
+  },
+};`,
+    // module-level directive: async exports
+    `"use server";
+export async function getUser(id) {
+  return db.get(id);
+}
+export const listUsers = async () => db.all();`,
+    // non-exported helpers in a module-level file only ever run in-process
+    `"use server";
+function normalize(user) {
+  return { ...user, name: user.name.trim() };
+}
+export async function getUser(id) {
+  return normalize(await db.get(id));
+}`,
+    // directives nested inside a server function are ignored by the transform
+    `export async function outer() {
+  "use server";
+  const inner = () => {
+    "use server";
+    return 1;
+  };
+  return inner();
+}`,
+  ],
+  invalid: [
+    {
+      code: `export const getUser = (id) => {
+  "use server";
+  return db.get(id);
+};`,
+      output: `export const getUser = async (id) => {
+  "use server";
+  return db.get(id);
+};`,
+      errors: [{ messageId: "asyncServerFunction" }],
+    },
+    {
+      code: `export function getUser(id) {
+  "use server";
+  return db.get(id);
+}`,
+      output: `export async function getUser(id) {
+  "use server";
+  return db.get(id);
+}`,
+      errors: [{ messageId: "asyncServerFunction" }],
+    },
+    // module-level directive: every exported function crosses the network
+    {
+      code: `"use server";
+export function getUser(id) {
+  return db.get(id);
+}`,
+      output: `"use server";
+export async function getUser(id) {
+  return db.get(id);
+}`,
+      errors: [{ messageId: "asyncServerFunction" }],
+    },
+    {
+      code: `"use server";
+export const listUsers = () => db.all();`,
+      output: `"use server";
+export const listUsers = async () => db.all();`,
+      errors: [{ messageId: "asyncServerFunction" }],
+    },
+    // export specifiers resolve to their top-level declarations
+    {
+      code: `"use server";
+function getUser(id) {
+  return db.get(id);
+}
+export { getUser };`,
+      output: `"use server";
+async function getUser(id) {
+  return db.get(id);
+}
+export { getUser };`,
+      errors: [{ messageId: "asyncServerFunction" }],
+    },
+    {
+      code: `"use server";
+export default function getUser(id) {
+  return db.get(id);
+}`,
+      output: `"use server";
+export default async function getUser(id) {
+  return db.get(id);
+}`,
+      errors: [{ messageId: "asyncServerFunction" }],
+    },
+  ],
+});

--- a/packages/eslint-plugin-solid/test/rules/valid-use-server.test.ts
+++ b/packages/eslint-plugin-solid/test/rules/valid-use-server.test.ts
@@ -1,0 +1,166 @@
+import { run } from "../ruleTester";
+import rule from "../../src/rules/valid-use-server";
+
+export const cases = run("valid-use-server", rule, {
+  valid: [
+    // function-level directive in the prologue of an eligible function
+    `export const getUser = async (id) => {
+  "use server";
+  return db.get(id);
+};`,
+    `export async function getUser(id) {
+  "use server";
+  return db.get(id);
+}`,
+    // other directives may precede it in the prologue
+    `async function getUser(id) {
+  "use strict";
+  "use server";
+  return db.get(id);
+}`,
+    // function-valued properties are eligible (unlike object methods)
+    `const api = {
+  getUser: async function (id) {
+    "use server";
+    return db.get(id);
+  },
+};`,
+    // a "use server" string in expression (non-statement) position is just a string
+    `const mode = "use server";
+function describe() {
+  return "use server";
+}`,
+    // module-level directive with async function exports
+    `"use server";
+export async function getUser(id) {
+  return db.get(id);
+}
+export const listUsers = async () => db.all();`,
+    // wrappers around function-level server functions are the supported pattern
+    `import { query } from "@solidjs/router";
+export const getUser = query(async (id) => {
+  "use server";
+  return db.get(id);
+}, "user");`,
+    // wrapper calls inside functions of a module-level file are server-side code
+    `"use server";
+import { query } from "@solidjs/router";
+export async function setup() {
+  return query(async (id) => db.get(id), "user");
+}`,
+    // re-exports are not statically analyzable; give them the benefit of the doubt
+    `"use server";
+export { helper } from "./helpers";`,
+    // directives nested inside a server function are ignored but harmless
+    `export async function outer() {
+  "use server";
+  const helpers = {
+    inner() {
+      "use server";
+      return 1;
+    },
+  };
+  return helpers.inner();
+}`,
+  ],
+  invalid: [
+    // directive after other statements is an ordinary expression statement
+    {
+      code: `async function getUser(id) {
+  const table = "users";
+  "use server";
+  return db.get(table, id);
+}`,
+      errors: [{ messageId: "misplacedDirective" }],
+    },
+    // a directive inside a plain block is never a directive
+    {
+      code: `async function getUser(id) {
+  if (id) {
+    "use server";
+    return db.get(id);
+  }
+}`,
+      errors: [{ messageId: "misplacedDirective" }],
+    },
+    // template literals are never directives
+    {
+      code: "async function getUser(id) {\n  `use server`;\n  return db.get(id);\n}",
+      errors: [{ messageId: "templateDirective" }],
+    },
+    {
+      code: "`use server`;\nexport async function getUser(id) {\n  return db.get(id);\n}",
+      errors: [{ messageId: "templateDirective" }],
+    },
+    // object methods are silently skipped by the compiler
+    {
+      code: `const api = {
+  async getUser(id) {
+    "use server";
+    return db.get(id);
+  },
+};`,
+      errors: [{ messageId: "ineligiblePosition", data: { position: "an object method" } }],
+    },
+    // getters and setters too
+    {
+      code: `const api = {
+  get user() {
+    "use server";
+    return db.get(1);
+  },
+};`,
+      errors: [{ messageId: "ineligiblePosition", data: { position: "a getter or setter" } }],
+    },
+    // and class methods
+    {
+      code: `class Api {
+  async getUser(id) {
+    "use server";
+    return db.get(id);
+  }
+}`,
+      errors: [{ messageId: "ineligiblePosition", data: { position: "a class method" } }],
+    },
+    // every export of a module-level directive file must be a function
+    {
+      code: `"use server";
+export const LIMIT = 10;
+export async function getUsers() {
+  return db.all();
+}`,
+      errors: [{ messageId: "nonFunctionExport", data: { name: "LIMIT" } }],
+    },
+    {
+      code: `"use server";
+export default { version: 1 };`,
+      errors: [{ messageId: "nonFunctionExport", data: { name: "default" } }],
+    },
+    // client wrappers are compiled out of the client in module-level files
+    {
+      code: `"use server";
+import { query } from "@solidjs/router";
+export const getUser = query(async (id) => db.get(id), "user");`,
+      errors: [{ messageId: "clientWrapper", data: { name: "query" } }],
+    },
+    {
+      code: `"use server";
+import { GET } from "@solidjs/web";
+export const listUsers = GET(async () => db.all());`,
+      errors: [{ messageId: "clientWrapper", data: { name: "GET" } }],
+    },
+    {
+      code: `"use server";
+import { action } from "@solidjs/router";
+export const save = action(async (data) => db.save(data));`,
+      errors: [{ messageId: "clientWrapper", data: { name: "action" } }],
+    },
+    // custom wrappers via the clientWrappers option, incl. wildcards
+    {
+      code: `"use server";
+export const getUser = defineLoader(async (id) => db.get(id));`,
+      options: [{ clientWrappers: ["define*"] }],
+      errors: [{ messageId: "clientWrapper", data: { name: "defineLoader" } }],
+    },
+  ],
+});

--- a/packages/eslint-solid-standalone/package.json
+++ b/packages/eslint-solid-standalone/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-solid-standalone",
-  "version": "0.16.1",
+  "version": "0.17.0",
   "description": "A bundle with eslint and eslint-plugin-solid that can be used in the browser.",
   "repository": "https://github.com/solidjs-community/eslint-plugin-solid",
   "license": "MIT",

--- a/test/format.test.ts
+++ b/test/format.test.ts
@@ -31,6 +31,10 @@ test("v2 configs set the Solid version and enable the 2.0 rules", () => {
   expect(v2Config.rules["solid/no-accessor-as-prop"]).toBe(2);
   expect(v2Config.rules["solid/prefer-structured-class"]).toBe(1);
   expect(v2Config.rules["solid/prefer-classlist"]).toBe(0);
+  expect(v2Config.rules["solid/valid-use-server"]).toBe(2);
+  expect(v2Config.rules["solid/require-async-server-function"]).toBe(2);
+  expect(v2Config.rules["solid/no-invalid-server-capture"]).toBe(2);
+  expect(v2Config.rules["solid/no-browser-globals-in-server-function"]).toBe(2);
   expect(v2StrictConfig.rules["solid/no-module-scope-reactive-primitive"]).toBe(2);
   expect(v2StrictConfig.rules["solid/prefer-onSettled-for-side-effects"]).toBe(1);
   expect(v2StrictConfig.rules["solid/no-restated-default-options"]).toBe(2);


### PR DESCRIPTION
## Summary

Server functions are core in Solid 2.0, so the plugin now lints them. Four new rules, all enabled as errors in the `v2`/`v2-strict` configs:

- **`solid/valid-use-server`** — the compiler silently ignores `"use server"` outside the directive prologue, in template literals, and in object/class methods, getters, and setters; this rule flags all of those. For module-level directive files it also flags non-function exports (server boot failure) and client declaration wrappers (`GET`, `live`, `withMeta`, `query`, `action`, `liveQuery`) whose client behavior is silently compiled out. A `clientWrappers` option adds custom names with wildcard/regex support.
- **`solid/require-async-server-function`** — non-async server functions return `T` during SSR but `Promise<T>` on the client, a split TS can't see. Covers function-level directives and all exports of module-level directive files. Autofixes by inserting `async`.
- **`solid/no-invalid-server-capture`** — editor-time mirror of the compiler's closure-capture validation: flags captures from intermediate scopes (component state, enclosing params) that don't exist where the extracted function runs. Allows module bindings, imports, globals, params/locals, self-references, and TS type-only references.
- **`solid/no-browser-globals-in-server-function`** — conservative list of browser-only globals (`window`, `document`, `localStorage`, …) inside server functions; server-provided web APIs (`fetch`, `crypto`, `navigator`) never warn, and shadowing/`typeof` guards are ignored.

Also extracts the reactivity rule's name-pattern matching into a shared `createNameMatcher` utility, and bumps to 0.17.0 (new rules = minor).

## Test plan

- [x] 709 rule tests pass on typescript-eslint, babel, and espree parsers
- [x] Full monorepo suite (unit + fixtures + standalone) passes
- [x] Self-lint (eslint-plugin/*) clean
- [x] Solid 2.0 template fixtures and sibling-checkout sweep: zero findings
- [x] Oxlint smoke test: all four rules fire correctly under jsPlugins

Made with [Cursor](https://cursor.com)