### PR TITLE
feat: add four Solid 2.0 correctness rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,10 +113,12 @@ export default [
 If your project targets Solid 2.0, use the `v2` configuration. It sets
 `settings: { solid: { version: 2 } }`, which switches the version-aware rules (`reactivity`,
 `imports`, `no-unknown-namespaces`, `event-handlers`, `jsx-no-undef`) to strict 2.0 semantics, and
-enables the 2.0-specific rules: `removed-api`, `no-single-arg-create-effect`, `no-accessor-as-prop`,
-and the server function rules (`valid-use-server`, `require-async-server-function`,
-`no-invalid-server-capture`, `no-browser-globals-in-server-function`) as errors and
-`prefer-structured-class` as a warning. This is the config the official Solid 2.0 templates ship
+enables the 2.0-specific rules: `removed-api`, `no-single-arg-create-effect`,
+`no-async-effect-half`, `no-accessor-as-prop`, `no-store-mutation-outside-setter`,
+`no-write-in-pure-computation`, and the server function rules (`valid-use-server`,
+`require-async-server-function`, `no-invalid-server-capture`,
+`no-browser-globals-in-server-function`) as errors, with `prefer-structured-class` and
+`no-unused-signal` as warnings. This is the config the official Solid 2.0 templates ship
 with.
 
 ```js
@@ -128,8 +130,8 @@ export default [js.configs.recommended, solid];
 
 There is also a `v2-strict` configuration with the plugin's strongest opinions: everything in `v2`
 plus `no-module-scope-reactive-primitive` and `no-restated-default-options` as errors,
-`prefer-onSettled-for-side-effects` as a warning, and `prefer-structured-class` promoted to an
-error.
+`prefer-onSettled-for-side-effects` as a warning, and `prefer-structured-class` and
+`no-unused-signal` promoted to errors.
 
 The `settings.solid.version` setting also works in any custom config; version-aware rules read it
 directly, so you can opt individual rule configurations into 2.0 semantics without using the
@@ -191,8 +193,9 @@ the plugin to `jsPlugins` in your `.oxlintrc.json` and enable the rules you want
 
 For Solid 2.0 projects, add `"settings": { "solid": { "version": 2 } }` to activate the
 version-aware rule behavior, and enable the 2.0 rules (`solid/removed-api`,
-`solid/no-single-arg-create-effect`, `solid/no-accessor-as-prop`,
-`solid/prefer-structured-class`, and the server function rules `solid/valid-use-server`,
+`solid/no-single-arg-create-effect`, `solid/no-async-effect-half`, `solid/no-accessor-as-prop`,
+`solid/no-store-mutation-outside-setter`, `solid/no-write-in-pure-computation`,
+`solid/no-unused-signal`, `solid/prefer-structured-class`, and the server function rules `solid/valid-use-server`,
 `solid/require-async-server-function`, `solid/no-invalid-server-capture`, and
 `solid/no-browser-globals-in-server-function`).
 
@@ -214,6 +217,7 @@ version-aware rule behavior, and enable the 2.0 rules (`solid/removed-api`,
 | ✔ |  | [solid/jsx-uses-vars](/packages/eslint-plugin-solid/docs/jsx-uses-vars.md) | Prevent variables used in JSX from being marked as unused. |
 |  |  | [solid/no-accessor-as-prop](/packages/eslint-plugin-solid/docs/no-accessor-as-prop.md) | Disallow passing uncalled signal accessors or other functions as value-typed DOM element attributes. |
 |  |  | [solid/no-array-handlers](/packages/eslint-plugin-solid/docs/no-array-handlers.md) | Disallow usage of type-unsafe event handlers. |
+|  |  | [solid/no-async-effect-half](/packages/eslint-plugin-solid/docs/no-async-effect-half.md) | Disallow async functions as the effect half of `createEffect(compute, effect)`, where a returned cleanup function would be silently discarded. |
 |  |  | [solid/no-browser-globals-in-server-function](/packages/eslint-plugin-solid/docs/no-browser-globals-in-server-function.md) | Disallow browser-only globals inside server functions, which run exclusively on the server. |
 | ✔ | 🔧 | [solid/no-destructure](/packages/eslint-plugin-solid/docs/no-destructure.md) | Disallow destructuring props. In Solid, props must be used with property accesses (`props.foo`) to preserve reactivity. This rule only tracks destructuring in the parameter list. |
 | ✔ | 🔧 | [solid/no-innerhtml](/packages/eslint-plugin-solid/docs/no-innerhtml.md) | Disallow usage of the innerHTML attribute, which can often lead to security vulnerabilities. |
@@ -224,7 +228,10 @@ version-aware rule behavior, and enable the 2.0 rules (`solid/removed-api`,
 | ✔ | 🔧 | [solid/no-react-specific-props](/packages/eslint-plugin-solid/docs/no-react-specific-props.md) | Disallow usage of React-specific `className`/`htmlFor` props, which were deprecated in v1.4.0. |
 |  | 🔧 | [solid/no-restated-default-options](/packages/eslint-plugin-solid/docs/no-restated-default-options.md) | Disallow restating a prop or option value that is already the default. |
 |  |  | [solid/no-single-arg-create-effect](/packages/eslint-plugin-solid/docs/no-single-arg-create-effect.md) | Require the two-argument `createEffect(compute, effect)` form used by Solid 2.0. |
+|  |  | [solid/no-store-mutation-outside-setter](/packages/eslint-plugin-solid/docs/no-store-mutation-outside-setter.md) | Disallow mutating a store's read proxy; store state changes only through the setter's mutable draft. |
 | ✔ |  | [solid/no-unknown-namespaces](/packages/eslint-plugin-solid/docs/no-unknown-namespaces.md) | Enforce using only Solid-specific namespaced attribute names (i.e. `'on:'` in `<div on:click={...} />`). |
+|  |  | [solid/no-unused-signal](/packages/eslint-plugin-solid/docs/no-unused-signal.md) | Disallow signals that are never written (use a plain value) or never read (dead state). |
+|  |  | [solid/no-write-in-pure-computation](/packages/eslint-plugin-solid/docs/no-write-in-pure-computation.md) | Disallow writing signals or stores inside `createMemo` or the compute half of `createEffect`, which must be pure. |
 |  | 🔧 | [solid/prefer-classlist](/packages/eslint-plugin-solid/docs/prefer-classlist.md) | Enforce using the classlist prop over importing a classnames helper. The classlist prop accepts an object `{ [class: string]: boolean }` just like classnames. |
 | ✔ | 🔧 | [solid/prefer-for](/packages/eslint-plugin-solid/docs/prefer-for.md) | Enforce using Solid's `<For />` component for mapping an array to JSX elements. |
 |  |  | [solid/prefer-onSettled-for-side-effects](/packages/eslint-plugin-solid/docs/prefer-onSettled-for-side-effects.md) | Enforce running side-effectful setup (timers, global listeners, observers) inside `onSettled` instead of the component body. |

--- a/packages/eslint-plugin-solid/README.md
+++ b/packages/eslint-plugin-solid/README.md
@@ -113,10 +113,12 @@ export default [
 If your project targets Solid 2.0, use the `v2` configuration. It sets
 `settings: { solid: { version: 2 } }`, which switches the version-aware rules (`reactivity`,
 `imports`, `no-unknown-namespaces`, `event-handlers`, `jsx-no-undef`) to strict 2.0 semantics, and
-enables the 2.0-specific rules: `removed-api`, `no-single-arg-create-effect`, `no-accessor-as-prop`,
-and the server function rules (`valid-use-server`, `require-async-server-function`,
-`no-invalid-server-capture`, `no-browser-globals-in-server-function`) as errors and
-`prefer-structured-class` as a warning. This is the config the official Solid 2.0 templates ship
+enables the 2.0-specific rules: `removed-api`, `no-single-arg-create-effect`,
+`no-async-effect-half`, `no-accessor-as-prop`, `no-store-mutation-outside-setter`,
+`no-write-in-pure-computation`, and the server function rules (`valid-use-server`,
+`require-async-server-function`, `no-invalid-server-capture`,
+`no-browser-globals-in-server-function`) as errors, with `prefer-structured-class` and
+`no-unused-signal` as warnings. This is the config the official Solid 2.0 templates ship
 with.
 
 ```js
@@ -128,8 +130,8 @@ export default [js.configs.recommended, solid];
 
 There is also a `v2-strict` configuration with the plugin's strongest opinions: everything in `v2`
 plus `no-module-scope-reactive-primitive` and `no-restated-default-options` as errors,
-`prefer-onSettled-for-side-effects` as a warning, and `prefer-structured-class` promoted to an
-error.
+`prefer-onSettled-for-side-effects` as a warning, and `prefer-structured-class` and
+`no-unused-signal` promoted to errors.
 
 The `settings.solid.version` setting also works in any custom config; version-aware rules read it
 directly, so you can opt individual rule configurations into 2.0 semantics without using the
@@ -191,8 +193,9 @@ the plugin to `jsPlugins` in your `.oxlintrc.json` and enable the rules you want
 
 For Solid 2.0 projects, add `"settings": { "solid": { "version": 2 } }` to activate the
 version-aware rule behavior, and enable the 2.0 rules (`solid/removed-api`,
-`solid/no-single-arg-create-effect`, `solid/no-accessor-as-prop`,
-`solid/prefer-structured-class`, and the server function rules `solid/valid-use-server`,
+`solid/no-single-arg-create-effect`, `solid/no-async-effect-half`, `solid/no-accessor-as-prop`,
+`solid/no-store-mutation-outside-setter`, `solid/no-write-in-pure-computation`,
+`solid/no-unused-signal`, `solid/prefer-structured-class`, and the server function rules `solid/valid-use-server`,
 `solid/require-async-server-function`, `solid/no-invalid-server-capture`, and
 `solid/no-browser-globals-in-server-function`).
 
@@ -214,6 +217,7 @@ version-aware rule behavior, and enable the 2.0 rules (`solid/removed-api`,
 | ✔ |  | [solid/jsx-uses-vars](/packages/eslint-plugin-solid/docs/jsx-uses-vars.md) | Prevent variables used in JSX from being marked as unused. |
 |  |  | [solid/no-accessor-as-prop](/packages/eslint-plugin-solid/docs/no-accessor-as-prop.md) | Disallow passing uncalled signal accessors or other functions as value-typed DOM element attributes. |
 |  |  | [solid/no-array-handlers](/packages/eslint-plugin-solid/docs/no-array-handlers.md) | Disallow usage of type-unsafe event handlers. |
+|  |  | [solid/no-async-effect-half](/packages/eslint-plugin-solid/docs/no-async-effect-half.md) | Disallow async functions as the effect half of `createEffect(compute, effect)`, where a returned cleanup function would be silently discarded. |
 |  |  | [solid/no-browser-globals-in-server-function](/packages/eslint-plugin-solid/docs/no-browser-globals-in-server-function.md) | Disallow browser-only globals inside server functions, which run exclusively on the server. |
 | ✔ | 🔧 | [solid/no-destructure](/packages/eslint-plugin-solid/docs/no-destructure.md) | Disallow destructuring props. In Solid, props must be used with property accesses (`props.foo`) to preserve reactivity. This rule only tracks destructuring in the parameter list. |
 | ✔ | 🔧 | [solid/no-innerhtml](/packages/eslint-plugin-solid/docs/no-innerhtml.md) | Disallow usage of the innerHTML attribute, which can often lead to security vulnerabilities. |
@@ -224,7 +228,10 @@ version-aware rule behavior, and enable the 2.0 rules (`solid/removed-api`,
 | ✔ | 🔧 | [solid/no-react-specific-props](/packages/eslint-plugin-solid/docs/no-react-specific-props.md) | Disallow usage of React-specific `className`/`htmlFor` props, which were deprecated in v1.4.0. |
 |  | 🔧 | [solid/no-restated-default-options](/packages/eslint-plugin-solid/docs/no-restated-default-options.md) | Disallow restating a prop or option value that is already the default. |
 |  |  | [solid/no-single-arg-create-effect](/packages/eslint-plugin-solid/docs/no-single-arg-create-effect.md) | Require the two-argument `createEffect(compute, effect)` form used by Solid 2.0. |
+|  |  | [solid/no-store-mutation-outside-setter](/packages/eslint-plugin-solid/docs/no-store-mutation-outside-setter.md) | Disallow mutating a store's read proxy; store state changes only through the setter's mutable draft. |
 | ✔ |  | [solid/no-unknown-namespaces](/packages/eslint-plugin-solid/docs/no-unknown-namespaces.md) | Enforce using only Solid-specific namespaced attribute names (i.e. `'on:'` in `<div on:click={...} />`). |
+|  |  | [solid/no-unused-signal](/packages/eslint-plugin-solid/docs/no-unused-signal.md) | Disallow signals that are never written (use a plain value) or never read (dead state). |
+|  |  | [solid/no-write-in-pure-computation](/packages/eslint-plugin-solid/docs/no-write-in-pure-computation.md) | Disallow writing signals or stores inside `createMemo` or the compute half of `createEffect`, which must be pure. |
 |  | 🔧 | [solid/prefer-classlist](/packages/eslint-plugin-solid/docs/prefer-classlist.md) | Enforce using the classlist prop over importing a classnames helper. The classlist prop accepts an object `{ [class: string]: boolean }` just like classnames. |
 | ✔ | 🔧 | [solid/prefer-for](/packages/eslint-plugin-solid/docs/prefer-for.md) | Enforce using Solid's `<For />` component for mapping an array to JSX elements. |
 |  |  | [solid/prefer-onSettled-for-side-effects](/packages/eslint-plugin-solid/docs/prefer-onSettled-for-side-effects.md) | Enforce running side-effectful setup (timers, global listeners, observers) inside `onSettled` instead of the component body. |

--- a/packages/eslint-plugin-solid/docs/no-async-effect-half.md
+++ b/packages/eslint-plugin-solid/docs/no-async-effect-half.md
@@ -1,0 +1,124 @@
+<!-- doc-gen HEADER -->
+# solid/no-async-effect-half
+Disallow async functions as the effect half of `createEffect(compute, effect)`, where a returned cleanup function would be silently discarded.
+This rule is **off** by default.
+
+[View source](../src/rules/no-async-effect-half.ts) · [View tests](../test/rules/no-async-effect-half.test.ts)
+<!-- end-doc-gen -->
+
+In Solid 2.0's split `createEffect(compute, effect)` form, the effect half may return a cleanup function that runs before the next execution and on disposal. Marking the effect function `async` breaks that contract twice over: the function now returns a Promise, so the cleanup it "returns" is silently discarded, and every statement after the first `await` runs detached from the effect's lifecycle — possibly after the effect has rerun or been disposed.
+
+```js
+// ✗ The abort cleanup is never registered, and setData may fire after disposal
+createEffect(
+  () => query(),
+  async (q) => {
+    const data = await fetch(q).then((r) => r.json());
+    setData(data);
+    return () => controller.abort(); // discarded: this resolves a Promise
+  }
+);
+
+// ✓ Do the async work in the compute half — async computations are tracked
+createEffect(
+  async () => (await fetch(query())).json(),
+  (data) => setData(data)
+);
+
+// ✓ Or start the work here and register cleanup synchronously
+createEffect(
+  () => query(),
+  (q) => {
+    const controller = new AbortController();
+    fetch(q, { signal: controller.signal }).then(handle);
+    return () => controller.abort();
+  }
+);
+```
+
+The compute half is exempt: async computations are first-class in Solid 2.0, and `solid/reactivity` understands their tracking semantics.
+
+This rule is enabled as an error in the `v2` and `v2-strict` configs.
+
+<!-- doc-gen OPTIONS -->
+<!-- end-doc-gen -->
+
+<!-- doc-gen CASES -->
+## Tests
+
+### Invalid Examples
+
+These snippets cause lint errors.
+
+```js
+import { createEffect } from "solid-js";
+createEffect(
+  () => query(),
+  async (q) => {
+    const data = await fetch(q);
+    setData(data);
+  }
+);
+
+import { createEffect } from "solid-js";
+createEffect(
+  () => query(),
+  async function (q) {
+    await save(q);
+  }
+);
+
+import { createRenderEffect } from "solid-js";
+createRenderEffect(
+  () => count(),
+  async (value) => update(await value)
+);
+
+import { createEffect } from "solid-js";
+async function persist(value) {
+  await save(value);
+}
+createEffect(() => count(), persist);
+
+import { createEffect } from "solid-js";
+const persist = async (value) => save(value);
+createEffect(() => count(), persist);
+
+```
+
+### Valid Examples
+
+These snippets don't cause lint errors.
+
+```js
+import { createEffect } from "solid-js";
+createEffect(
+  () => count(),
+  (value) => console.log(value)
+);
+
+import { createEffect } from "solid-js";
+createEffect(
+  async () => (await fetch(url())).json(),
+  (data) => setData(data)
+);
+
+import { createEffect } from "solid-js";
+createEffect(
+  () => query(),
+  (q) => {
+    const controller = new AbortController();
+    fetch(q, { signal: controller.signal }).then(handle);
+    return () => controller.abort();
+  }
+);
+
+import { createEffect } from "solid-js";
+createEffect(async () => console.log(await promise));
+
+import { createEffect } from "solid-js";
+const log = (value) => console.log(value);
+createEffect(() => count(), log);
+
+```
+<!-- end-doc-gen -->

--- a/packages/eslint-plugin-solid/docs/no-store-mutation-outside-setter.md
+++ b/packages/eslint-plugin-solid/docs/no-store-mutation-outside-setter.md
@@ -1,0 +1,111 @@
+<!-- doc-gen HEADER -->
+# solid/no-store-mutation-outside-setter
+Disallow mutating a store's read proxy; store state changes only through the setter's mutable draft.
+This rule is **off** by default.
+
+[View source](../src/rules/no-store-mutation-outside-setter.ts) · [View tests](../test/rules/no-store-mutation-outside-setter.test.ts)
+<!-- end-doc-gen -->
+
+Store setters receive a mutable draft in Solid 2.0 (`produce` semantics by default), which makes mutating the read proxy directly look plausible — especially for code migrating from `createMutable`. It isn't: the read proxy is read-only, so the mutation throws in dev mode and silently fails to trigger updates otherwise.
+
+```js
+const [store, setStore] = createStore({ count: 0, items: [] });
+
+// ✗ Mutating the read proxy
+store.count++;
+store.items.push(item);
+delete store.stale;
+
+// ✓ Mutating the draft inside the setter
+setStore((draft) => {
+  draft.count++;
+  draft.items.push(item);
+  delete draft.stale;
+});
+```
+
+The rule resolves the mutated object back to its `createStore` destructure, so plain objects, `snapshot()` copies, and setter draft parameters (even ones shadowing the store's name) are never flagged. Mutating method calls are limited to the built-in mutating array methods (`push`, `splice`, `sort`, …).
+
+Projections (`createProjection`) are read-only derived stores, so mutating one is flagged with guidance to derive the value inside the projection function instead.
+
+This rule is enabled as an error in the `v2` and `v2-strict` configs.
+
+<!-- doc-gen OPTIONS -->
+<!-- end-doc-gen -->
+
+<!-- doc-gen CASES -->
+## Tests
+
+### Invalid Examples
+
+These snippets cause lint errors.
+
+```js
+import { createStore } from "solid-js";
+const [store, setStore] = createStore({ count: 0 });
+store.count = 5;
+
+import { createStore } from "solid-js";
+const [store, setStore] = createStore({ count: 0 });
+store.count++;
+
+import { createStore } from "solid-js";
+const [store, setStore] = createStore({ items: [] });
+store.items.push(item);
+
+import { createStore } from "solid-js";
+const [store, setStore] = createStore({ user: { name: "a" } });
+delete store.user.name;
+
+import { createStore } from "solid-js";
+const [store, setStore] = createStore({ nested: { deep: { value: 0 } } });
+store.nested.deep.value = 1;
+
+import { createStore } from "solid-js";
+const [store, setStore] = createStore({ count: 0 });
+setStore(() => {
+  store.count = 5;
+});
+
+import { createProjection } from "solid-js";
+const selected = createProjection((draft) => {
+  draft[selectedId()] = true;
+});
+selected.other = true;
+
+```
+
+### Valid Examples
+
+These snippets don't cause lint errors.
+
+```js
+import { createStore } from "solid-js";
+const [store, setStore] = createStore({ count: 0 });
+setStore((draft) => {
+  draft.count++;
+});
+console.log(store.count);
+
+import { createStore } from "solid-js";
+const [store, setStore] = createStore({ count: 0 });
+setStore((store) => {
+  store.count = 5;
+});
+
+import { createStore, snapshot } from "solid-js";
+const [store, setStore] = createStore({ items: [] });
+const copy = snapshot(store);
+copy.items.push(1);
+
+import { createStore } from "solid-js";
+const [store, setStore] = createStore({ items: [] });
+const doubled = store.items.map((n) => n * 2);
+setStore((draft) => (draft.items = doubled));
+
+const obj = { count: 0 };
+obj.count++;
+delete obj.count;
+
+```
+<!-- end-doc-gen -->

--- a/packages/eslint-plugin-solid/docs/no-unused-signal.md
+++ b/packages/eslint-plugin-solid/docs/no-unused-signal.md
@@ -1,0 +1,92 @@
+<!-- doc-gen HEADER -->
+# solid/no-unused-signal
+Disallow signals that are never written (use a plain value) or never read (dead state).
+This rule is **off** by default.
+
+[View source](../src/rules/no-unused-signal.ts) · [View tests](../test/rules/no-unused-signal.test.ts)
+<!-- end-doc-gen -->
+
+A destructured signal tuple is the only handle on the signal, so scope analysis is conclusive: if the setter is never referenced, the value can never change and the signal is really a constant; if the accessor is never referenced, the state can never be observed and every write is dead code. Unused-variable rules miss both cases because the *other* half of the tuple keeps the declaration "used".
+
+```js
+// ✗ Never written — this is a constant wearing a signal costume
+const [limit, setLimit] = createSignal(10);
+return <List max={limit()} />;
+
+// ✓ A plain accessor keeps call sites identical
+const limit = () => 10;
+
+// ✓ Or createMemo, if the value derives from reactive state
+const limit = createMemo(() => props.pageSize ?? 10);
+```
+
+```js
+// ✗ Never read — state that's only written has no effect
+const [lastSaved, setLastSaved] = createSignal(null);
+const save = () => setLastSaved(Date.now());
+```
+
+Never-written signals with a literal initial value get an editor suggestion rewriting them to a constant accessor. Exported signal declarations are skipped, since other modules may read or write them.
+
+This rule commonly fires on leftover scaffolding after a Solid 1.x → 2.0 migration, such as signals that used to mirror a `createResource`.
+
+This rule is enabled as a warning in the `v2` config and an error in `v2-strict`.
+
+<!-- doc-gen OPTIONS -->
+<!-- end-doc-gen -->
+
+<!-- doc-gen CASES -->
+## Tests
+
+### Invalid Examples
+
+These snippets cause lint errors.
+
+```js
+import { createSignal } from "solid-js";
+const [count, setCount] = createSignal(0);
+console.log(count());
+
+import { createSignal } from "solid-js";
+const [count] = createSignal(0);
+console.log(count());
+
+import { createSignal } from "solid-js";
+const [items, setItems] = createSignal([]);
+console.log(items());
+
+import { createSignal } from "solid-js";
+const [count, setCount] = createSignal(0);
+setCount(5);
+
+import { createSignal } from "solid-js";
+const [, setCount] = createSignal(0);
+setCount(5);
+
+```
+
+### Valid Examples
+
+These snippets don't cause lint errors.
+
+```js
+import { createSignal } from "solid-js";
+const [count, setCount] = createSignal(0);
+console.log(count());
+setCount(1);
+
+import { createSignal } from "solid-js";
+function Counter() {
+  const [count, setCount] = createSignal(0);
+  return <Child value={count} onIncrement={setCount} />;
+}
+
+import { createSignal } from "solid-js";
+export const [theme, setTheme] = createSignal("light");
+
+import { createSignal } from "solid-js";
+const tuple = createSignal(0);
+use(tuple);
+
+```
+<!-- end-doc-gen -->

--- a/packages/eslint-plugin-solid/docs/no-write-in-pure-computation.md
+++ b/packages/eslint-plugin-solid/docs/no-write-in-pure-computation.md
@@ -1,0 +1,113 @@
+<!-- doc-gen HEADER -->
+# solid/no-write-in-pure-computation
+Disallow writing signals or stores inside `createMemo` or the compute half of `createEffect`, which must be pure.
+This rule is **off** by default.
+
+[View source](../src/rules/no-write-in-pure-computation.ts) · [View tests](../test/rules/no-write-in-pure-computation.test.ts)
+<!-- end-doc-gen -->
+
+`createMemo` callbacks and the compute half of `createEffect(compute, effect)` are pure tracked computations: writing other reactive state from inside them creates update cycles, and Solid 2.0 throws on it in dev mode. The usual intent — deriving one piece of state from another — has a first-class answer that doesn't need a write at all.
+
+```js
+// ✗ Deriving state by writing a signal from a computation
+const bad = createMemo(() => {
+  setDouble(count() * 2);
+  return count();
+});
+
+// ✓ Derive it — no second signal needed
+const double = createMemo(() => count() * 2);
+```
+
+```js
+// ✗ The compute half is tracked and must be pure
+createEffect(() => {
+  setLog(query()); // write during tracking
+  return query();
+}, (value) => console.log(value));
+
+// ✓ Writes belong in the effect half
+createEffect(() => query(), (value) => setLog(value));
+```
+
+Only setter calls whose nearest enclosing function *is* the computation are flagged. A setter inside a nested function — say, an event handler the memo returns — runs later, outside the computation, and is fine. Setters are recognized by resolving to the second element of a `createSignal`, `createStore`, or `createOptimistic` destructure.
+
+This rule is enabled as an error in the `v2` and `v2-strict` configs.
+
+<!-- doc-gen OPTIONS -->
+<!-- end-doc-gen -->
+
+<!-- doc-gen CASES -->
+## Tests
+
+### Invalid Examples
+
+These snippets cause lint errors.
+
+```js
+import { createSignal, createMemo } from "solid-js";
+const [count, setCount] = createSignal(0);
+const bad = createMemo(() => {
+  setCount(count() + 1);
+  return count();
+});
+
+import { createSignal, createEffect } from "solid-js";
+const [log, setLog] = createSignal("");
+createEffect(
+  () => {
+    setLog(query());
+    return query();
+  },
+  (value) => console.log(value)
+);
+
+import { createSignal, createRenderEffect } from "solid-js";
+const [size, setSize] = createSignal(0);
+createRenderEffect(
+  () => {
+    setSize(width());
+    return width();
+  },
+  (value) => update(value)
+);
+
+import { createStore, createMemo } from "solid-js";
+const [store, setStore] = createStore({ count: 0 });
+const bad = createMemo(() => {
+  setStore((draft) => draft.count++);
+  return store.count;
+});
+
+```
+
+### Valid Examples
+
+These snippets don't cause lint errors.
+
+```js
+import { createSignal, createEffect } from "solid-js";
+const [count, setCount] = createSignal(0);
+const [double, setDouble] = createSignal(0);
+createEffect(
+  () => count(),
+  (value) => setDouble(value * 2)
+);
+
+import { createSignal, createMemo } from "solid-js";
+const [count, setCount] = createSignal(0);
+const handler = createMemo(() => () => setCount(count() + 1));
+
+import { createSignal } from "solid-js";
+const [count, setCount] = createSignal(0);
+setCount(5);
+
+import { createSignal, createMemo } from "solid-js";
+const [count, setCount] = createSignal(0);
+const double = createMemo(() => count() * 2);
+
+import { createMemo } from "solid-js";
+const result = createMemo(() => transform(input()));
+
+```
+<!-- end-doc-gen -->

--- a/packages/eslint-plugin-solid/src/configs/v2-strict.ts
+++ b/packages/eslint-plugin-solid/src/configs/v2-strict.ts
@@ -20,6 +20,8 @@ const v2Strict = {
     "solid/no-restated-default-options": 2,
     // graduate the class-string heuristic to an error
     "solid/prefer-structured-class": 2,
+    // graduate the half-unused signal check to an error
+    "solid/no-unused-signal": 2,
   },
 } satisfies TSESLint.FlatConfig.Config;
 

--- a/packages/eslint-plugin-solid/src/configs/v2.ts
+++ b/packages/eslint-plugin-solid/src/configs/v2.ts
@@ -29,6 +29,14 @@ const v2 = {
     "solid/removed-api": 2,
     // 2.0 requires the split createEffect(compute, effect) form
     "solid/no-single-arg-create-effect": 2,
+    // an async effect half discards its cleanup return and outlives the effect
+    "solid/no-async-effect-half": 2,
+    // the store read proxy is read-only; mutations go through the setter's draft
+    "solid/no-store-mutation-outside-setter": 2,
+    // writes inside memos/compute halves create cycles and throw in 2.0 dev
+    "solid/no-write-in-pure-computation": 2,
+    // signals that are never written (or never read) aren't being used as signals
+    "solid/no-unused-signal": 1,
     // uncalled accessors as DOM attributes render stringified functions
     "solid/no-accessor-as-prop": 2,
     // manual class-string building works but defeats granular class toggling

--- a/packages/eslint-plugin-solid/src/plugin.ts
+++ b/packages/eslint-plugin-solid/src/plugin.ts
@@ -14,6 +14,7 @@ import jsxNoScriptUrl from "./rules/jsx-no-script-url";
 import jsxNoUndef from "./rules/jsx-no-undef";
 import jsxUsesVars from "./rules/jsx-uses-vars";
 import noAccessorAsProp from "./rules/no-accessor-as-prop";
+import noAsyncEffectHalf from "./rules/no-async-effect-half";
 import noBrowserGlobalsInServerFunction from "./rules/no-browser-globals-in-server-function";
 import noDestructure from "./rules/no-destructure";
 import noInnerHTML from "./rules/no-innerhtml";
@@ -24,7 +25,10 @@ import noReactDeps from "./rules/no-react-deps";
 import noReactSpecificProps from "./rules/no-react-specific-props";
 import noRestatedDefaultOptions from "./rules/no-restated-default-options";
 import noSingleArgCreateEffect from "./rules/no-single-arg-create-effect";
+import noStoreMutationOutsideSetter from "./rules/no-store-mutation-outside-setter";
 import noUnknownNamespaces from "./rules/no-unknown-namespaces";
+import noUnusedSignal from "./rules/no-unused-signal";
+import noWriteInPureComputation from "./rules/no-write-in-pure-computation";
 import preferClasslist from "./rules/prefer-classlist";
 import preferFor from "./rules/prefer-for";
 import preferOnSettledForSideEffects from "./rules/prefer-onSettled-for-side-effects";
@@ -53,6 +57,7 @@ const allRules = {
   "jsx-no-script-url": jsxNoScriptUrl,
   "jsx-uses-vars": jsxUsesVars,
   "no-accessor-as-prop": noAccessorAsProp,
+  "no-async-effect-half": noAsyncEffectHalf,
   "no-browser-globals-in-server-function": noBrowserGlobalsInServerFunction,
   "no-destructure": noDestructure,
   "no-innerhtml": noInnerHTML,
@@ -63,7 +68,10 @@ const allRules = {
   "no-react-specific-props": noReactSpecificProps,
   "no-restated-default-options": noRestatedDefaultOptions,
   "no-single-arg-create-effect": noSingleArgCreateEffect,
+  "no-store-mutation-outside-setter": noStoreMutationOutsideSetter,
   "no-unknown-namespaces": noUnknownNamespaces,
+  "no-unused-signal": noUnusedSignal,
+  "no-write-in-pure-computation": noWriteInPureComputation,
   "prefer-classlist": preferClasslist,
   "prefer-for": preferFor,
   "prefer-onSettled-for-side-effects": preferOnSettledForSideEffects,

--- a/packages/eslint-plugin-solid/src/rules/no-async-effect-half.ts
+++ b/packages/eslint-plugin-solid/src/rules/no-async-effect-half.ts
@@ -1,0 +1,70 @@
+/**
+ * FIXME: remove this comments and import when below issue is fixed.
+ * This import is necessary for type generation due to a bug in the TypeScript compiler.
+ * See: https://github.com/microsoft/TypeScript/issues/42873
+ */
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+import type { TSESLint } from "@typescript-eslint/utils";
+
+import { TSESTree as T, ESLintUtils } from "@typescript-eslint/utils";
+import { findVariable } from "../compat";
+import { isFunctionNode, trackImports } from "../utils";
+
+const createRule = ESLintUtils.RuleCreator.withoutDocs;
+
+type MessageIds = "asyncEffect";
+type Options = [];
+
+/*
+ * In Solid 2.0's split `createEffect(compute, effect)` form, the effect half
+ * may return a cleanup function. An async effect function returns a Promise
+ * instead, so the cleanup it "returns" is silently discarded — and statements
+ * after the first `await` run detached from the effect's lifecycle, possibly
+ * after the effect has been rerun or disposed. The compute half is exempt:
+ * async computations are first-class in Solid 2.0.
+ */
+export default createRule<Options, MessageIds>({
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "Disallow async functions as the effect half of `createEffect(compute, effect)`, where a returned cleanup function would be silently discarded.",
+      url: "https://github.com/solidjs-community/eslint-plugin-solid/blob/main/packages/eslint-plugin-solid/docs/no-async-effect-half.md",
+    },
+    schema: [],
+    messages: {
+      asyncEffect:
+        "The effect half of {{name}} must be synchronous: an async function returns a Promise, so its cleanup return value is discarded and code after `await` runs outside the effect's lifecycle. Do the async work in the compute half (async computations are tracked), or start it here and register cleanup synchronously.",
+    },
+  },
+  defaultOptions: [],
+  create(context) {
+    const { matchImport, handleImportDeclaration } = trackImports();
+
+    /** Resolves an identifier to the function it names, if statically knowable. */
+    const resolveFunction = (id: T.Identifier): T.Node | null => {
+      const def = findVariable(context, id)?.defs[0];
+      if (!def) return null;
+      if (def.type === "FunctionName") return def.node;
+      if (def.type === "Variable" && def.node.init && isFunctionNode(def.node.init)) {
+        return def.node.init;
+      }
+      return null;
+    };
+
+    return {
+      ImportDeclaration: handleImportDeclaration,
+      CallExpression(node) {
+        if (node.callee.type !== "Identifier" || node.arguments.length < 2) return;
+        const name = matchImport(["createEffect", "createRenderEffect"], node.callee.name);
+        if (!name) return;
+
+        const effectHalf = node.arguments[1];
+        const fn = effectHalf.type === "Identifier" ? resolveFunction(effectHalf) : effectHalf;
+        if (fn && isFunctionNode(fn) && fn.async) {
+          context.report({ node: effectHalf, messageId: "asyncEffect", data: { name } });
+        }
+      },
+    };
+  },
+});

--- a/packages/eslint-plugin-solid/src/rules/no-store-mutation-outside-setter.ts
+++ b/packages/eslint-plugin-solid/src/rules/no-store-mutation-outside-setter.ts
@@ -1,0 +1,136 @@
+/**
+ * FIXME: remove this comments and import when below issue is fixed.
+ * This import is necessary for type generation due to a bug in the TypeScript compiler.
+ * See: https://github.com/microsoft/TypeScript/issues/42873
+ */
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+import type { TSESLint } from "@typescript-eslint/utils";
+
+import { TSESTree as T, ESLintUtils } from "@typescript-eslint/utils";
+import { findVariable } from "../compat";
+import { trackImports } from "../utils";
+
+const createRule = ESLintUtils.RuleCreator.withoutDocs;
+
+// Array methods that mutate their receiver in place.
+const MUTATING_METHODS = new Set([
+  "push",
+  "pop",
+  "shift",
+  "unshift",
+  "splice",
+  "sort",
+  "reverse",
+  "fill",
+  "copyWithin",
+]);
+
+type MessageIds = "mutateStore" | "mutateProjection";
+type Options = [];
+
+/*
+ * Store setters receive a mutable draft in Solid 2.0 (`produce` semantics by
+ * default), which makes mutating the read proxy directly — `store.count++`,
+ * `store.items.push(x)` — look plausible. It isn't: the read proxy is
+ * read-only, so the mutation throws in dev and silently fails to trigger
+ * updates otherwise. Draft mutations inside the setter are written through the
+ * draft parameter, a different variable, so they never resolve to the store
+ * and are naturally exempt.
+ */
+export default createRule<Options, MessageIds>({
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "Disallow mutating a store's read proxy; store state changes only through the setter's mutable draft.",
+      url: "https://github.com/solidjs-community/eslint-plugin-solid/blob/main/packages/eslint-plugin-solid/docs/no-store-mutation-outside-setter.md",
+    },
+    schema: [],
+    messages: {
+      mutateStore:
+        "'{{name}}' is a store's read proxy, which is read-only; this mutation throws in dev and never triggers updates. Mutate the draft inside the setter instead: `{{setter}}(draft => { ... })`.",
+      mutateProjection:
+        "'{{name}}' is a projection, a read-only derived store. Derive this value inside the projection function instead of mutating the result.",
+    },
+  },
+  defaultOptions: [],
+  create(context) {
+    const { matchImport, handleImportDeclaration } = trackImports();
+
+    type Target = { kind: "store"; setter: string | null } | { kind: "projection" };
+
+    /** Resolves an identifier to the store or projection it names, if any. */
+    const resolveTarget = (id: T.Identifier): Target | null => {
+      const def = findVariable(context, id)?.defs[0];
+      if (!def || def.type !== "Variable" || !def.node.init) return null;
+      const { id: declId, init } = def.node;
+      if (init.type !== "CallExpression" || init.callee.type !== "Identifier") return null;
+
+      // const [store, setStore] = createStore(...)
+      if (
+        declId.type === "ArrayPattern" &&
+        declId.elements[0]?.type === "Identifier" &&
+        declId.elements[0].name === id.name &&
+        matchImport("createStore", init.callee.name)
+      ) {
+        const setter = declId.elements[1]?.type === "Identifier" ? declId.elements[1].name : null;
+        return { kind: "store", setter };
+      }
+      // const projected = createProjection(...)
+      if (declId.type === "Identifier" && matchImport("createProjection", init.callee.name)) {
+        return { kind: "projection" };
+      }
+      return null;
+    };
+
+    /** Walks a member chain (`store.a.b`) down to its base identifier. */
+    const baseIdentifier = (node: T.Node): T.Identifier | null => {
+      let current: T.Node = node;
+      while (current.type === "MemberExpression") current = current.object;
+      return current.type === "Identifier" ? current : null;
+    };
+
+    const checkMutation = (member: T.MemberExpression, reportNode: T.Node) => {
+      const base = baseIdentifier(member);
+      const target = base && resolveTarget(base);
+      if (!target) return;
+      if (target.kind === "projection") {
+        context.report({
+          node: reportNode,
+          messageId: "mutateProjection",
+          data: { name: base.name },
+        });
+      } else {
+        context.report({
+          node: reportNode,
+          messageId: "mutateStore",
+          data: { name: base.name, setter: target.setter ?? "setStore" },
+        });
+      }
+    };
+
+    return {
+      ImportDeclaration: handleImportDeclaration,
+      AssignmentExpression(node) {
+        if (node.left.type === "MemberExpression") checkMutation(node.left, node);
+      },
+      UpdateExpression(node) {
+        if (node.argument.type === "MemberExpression") checkMutation(node.argument, node);
+      },
+      UnaryExpression(node) {
+        if (node.operator === "delete" && node.argument.type === "MemberExpression") {
+          checkMutation(node.argument, node);
+        }
+      },
+      CallExpression(node) {
+        if (
+          node.callee.type === "MemberExpression" &&
+          node.callee.property.type === "Identifier" &&
+          MUTATING_METHODS.has(node.callee.property.name)
+        ) {
+          checkMutation(node.callee, node);
+        }
+      },
+    };
+  },
+});

--- a/packages/eslint-plugin-solid/src/rules/no-unused-signal.ts
+++ b/packages/eslint-plugin-solid/src/rules/no-unused-signal.ts
@@ -1,0 +1,107 @@
+import type { TSESLint } from "@typescript-eslint/utils";
+
+import { TSESTree as T, ESLintUtils } from "@typescript-eslint/utils";
+import { findVariable, getSourceCode } from "../compat";
+import { findParent, trackImports } from "../utils";
+
+const createRule = ESLintUtils.RuleCreator.withoutDocs;
+
+type MessageIds = "neverWritten" | "neverRead" | "replaceWithAccessor";
+type Options = [];
+
+/*
+ * A destructured signal tuple is the only handle on the signal, so scope
+ * analysis is conclusive: if the setter is never referenced the value can
+ * never change, and if the accessor is never referenced the state can never
+ * be observed. Unused-variable rules miss both halves because the *other*
+ * half keeps the declaration "used". Exported declarations are skipped —
+ * references in other modules are invisible here.
+ */
+export default createRule<Options, MessageIds>({
+  meta: {
+    type: "suggestion",
+    docs: {
+      description:
+        "Disallow signals that are never written (use a plain value) or never read (dead state).",
+      url: "https://github.com/solidjs-community/eslint-plugin-solid/blob/main/packages/eslint-plugin-solid/docs/no-unused-signal.md",
+    },
+    hasSuggestions: true,
+    schema: [],
+    messages: {
+      neverWritten:
+        "This signal is never written, so its value can never change. Use a plain constant (`const {{accessor}} = () => value`), or `createMemo` if the value is derived from reactive state.",
+      neverRead:
+        "This signal is never read, so setting it has no effect. Remove the signal, or read the value where the state should be used.",
+      replaceWithAccessor: "Replace with a constant accessor.",
+    },
+  },
+  defaultOptions: [],
+  create(context) {
+    const { matchImport, handleImportDeclaration } = trackImports();
+
+    /** Does this pattern element's variable have any reference besides its initialization? */
+    const isUsed = (element: T.Identifier): boolean => {
+      const variable = findVariable(context, element);
+      // Unresolvable variables can't be proven unused; assume they're fine.
+      if (!variable) return true;
+      return variable.references.some((ref) => !ref.init);
+    };
+
+    return {
+      ImportDeclaration: handleImportDeclaration,
+      VariableDeclarator(node) {
+        if (
+          node.init?.type !== "CallExpression" ||
+          node.init.callee.type !== "Identifier" ||
+          !matchImport("createSignal", node.init.callee.name) ||
+          node.id.type !== "ArrayPattern" ||
+          node.id.elements.length > 2
+        ) {
+          return;
+        }
+        // Only plain `[accessor, setter]` shapes (with possible holes) are conclusive.
+        const [accessor = null, setter = null] = node.id.elements;
+        if (
+          (accessor && accessor.type !== "Identifier") ||
+          (setter && setter.type !== "Identifier")
+        ) {
+          return;
+        }
+        // Exported signals can be read or written by other modules.
+        if (findParent(node, (n) => n.type === "ExportNamedDeclaration")) return;
+
+        if (!accessor || !isUsed(accessor)) {
+          context.report({ node: accessor ?? node.id, messageId: "neverRead" });
+          return;
+        }
+        if (!setter || !isUsed(setter)) {
+          const init = node.init;
+          const initialValue = init.arguments[0];
+          // Only suggest the rewrite when the initial value is a simple literal;
+          // richer expressions may want createMemo or evaluate-once semantics.
+          const suggest =
+            !initialValue || initialValue.type === "Literal"
+              ? [
+                  {
+                    messageId: "replaceWithAccessor" as const,
+                    fix: (fixer: TSESLint.RuleFixer) =>
+                      fixer.replaceText(
+                        node,
+                        `${accessor.name} = () => ${
+                          initialValue ? getSourceCode(context).getText(initialValue) : "undefined"
+                        }`
+                      ),
+                  },
+                ]
+              : undefined;
+          context.report({
+            node: setter ?? node.id,
+            messageId: "neverWritten",
+            data: { accessor: accessor.name },
+            suggest,
+          });
+        }
+      },
+    };
+  },
+});

--- a/packages/eslint-plugin-solid/src/rules/no-write-in-pure-computation.ts
+++ b/packages/eslint-plugin-solid/src/rules/no-write-in-pure-computation.ts
@@ -1,0 +1,100 @@
+/**
+ * FIXME: remove this comments and import when below issue is fixed.
+ * This import is necessary for type generation due to a bug in the TypeScript compiler.
+ * See: https://github.com/microsoft/TypeScript/issues/42873
+ */
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+import type { TSESLint } from "@typescript-eslint/utils";
+
+import { TSESTree as T, ESLintUtils } from "@typescript-eslint/utils";
+import { findVariable } from "../compat";
+import { findParent, isFunctionNode, trackImports } from "../utils";
+
+const createRule = ESLintUtils.RuleCreator.withoutDocs;
+
+type MessageIds = "writeInMemo" | "writeInCompute";
+type Options = [];
+
+/*
+ * `createMemo` callbacks and the compute half of `createEffect(compute,
+ * effect)` are pure tracked computations: writing other reactive state from
+ * inside them creates update cycles and throws in Solid 2.0 dev mode. Only
+ * setter calls whose nearest enclosing function IS the computation are
+ * flagged — a setter inside a nested function (say, an event handler the
+ * memo returns) runs later, outside the computation, and is fine.
+ */
+export default createRule<Options, MessageIds>({
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "Disallow writing signals or stores inside `createMemo` or the compute half of `createEffect`, which must be pure.",
+      url: "https://github.com/solidjs-community/eslint-plugin-solid/blob/main/packages/eslint-plugin-solid/docs/no-write-in-pure-computation.md",
+    },
+    schema: [],
+    messages: {
+      writeInMemo:
+        "Calling the setter '{{name}}' inside createMemo makes the computation impure and creates an update cycle. Derive the value instead of storing it, or move the write to an effect.",
+      writeInCompute:
+        "Calling the setter '{{name}}' in the compute half of {{api}} — the compute function is tracked and must be pure. Move the write into the effect half (the second argument).",
+    },
+  },
+  defaultOptions: [],
+  create(context) {
+    const { matchImport, handleImportDeclaration } = trackImports();
+
+    /** Pure computation functions seen so far, mapped to how to report writes in them. */
+    const computations = new Map<T.Node, { messageId: MessageIds; api: string }>();
+
+    /** Is `id` the setter half of a signal/store/optimistic tuple? */
+    const isSetter = (id: T.Identifier): boolean => {
+      const def = findVariable(context, id)?.defs[0];
+      if (!def || def.type !== "Variable" || !def.node.init) return false;
+      const { id: declId, init } = def.node;
+      return (
+        declId.type === "ArrayPattern" &&
+        declId.elements[1]?.type === "Identifier" &&
+        declId.elements[1].name === id.name &&
+        init.type === "CallExpression" &&
+        init.callee.type === "Identifier" &&
+        !!matchImport(["createSignal", "createStore", "createOptimistic"], init.callee.name)
+      );
+    };
+
+    return {
+      ImportDeclaration: handleImportDeclaration,
+      CallExpression(node) {
+        if (node.callee.type !== "Identifier") return;
+
+        // Register pure computation callbacks. Ancestors are visited before
+        // descendants, so these are known before their setter calls are seen.
+        if (matchImport("createMemo", node.callee.name)) {
+          const fn = node.arguments[0];
+          if (isFunctionNode(fn)) {
+            computations.set(fn, { messageId: "writeInMemo", api: "createMemo" });
+          }
+          return;
+        }
+        const effectName = matchImport(["createEffect", "createRenderEffect"], node.callee.name);
+        if (effectName && node.arguments.length >= 2) {
+          const fn = node.arguments[0];
+          if (isFunctionNode(fn)) {
+            computations.set(fn, { messageId: "writeInCompute", api: effectName });
+          }
+          return;
+        }
+
+        if (computations.size === 0) return;
+        const enclosing = findParent(node, isFunctionNode);
+        const computation = enclosing && computations.get(enclosing);
+        if (computation && isSetter(node.callee)) {
+          context.report({
+            node,
+            messageId: computation.messageId,
+            data: { name: node.callee.name, api: computation.api },
+          });
+        }
+      },
+    };
+  },
+});

--- a/packages/eslint-plugin-solid/test/rules/no-async-effect-half.imports.test.ts
+++ b/packages/eslint-plugin-solid/test/rules/no-async-effect-half.imports.test.ts
@@ -1,0 +1,29 @@
+import { vi } from "vitest";
+
+// The global vitest setup mocks trackImports so most rule tests can skip
+// import boilerplate. These cases exercise the real import gating — foreign
+// createEffects excluded, Solid aliases resolved — so restore it here. This
+// file is intentionally not named `<rule>.test.ts`: scripts/docs.mts imports
+// test files by that name to build docs and cannot load files using vitest
+// APIs.
+vi.unmock("../../src/utils");
+
+import { run } from "../ruleTester";
+import rule from "../../src/rules/no-async-effect-half";
+
+export const cases = run("no-async-effect-half", rule, {
+  valid: [
+    // not Solid's createEffect
+    `const createEffect = (compute, effect) => effect(compute());
+createEffect(() => count(), async (value) => save(value));`,
+    `import { createEffect } from "another-library";
+createEffect(() => count(), async (value) => save(value));`,
+  ],
+  invalid: [
+    {
+      code: `import { createEffect as effect } from "solid-js";
+effect(() => count(), async (value) => save(value));`,
+      errors: [{ messageId: "asyncEffect" }],
+    },
+  ],
+});

--- a/packages/eslint-plugin-solid/test/rules/no-async-effect-half.test.ts
+++ b/packages/eslint-plugin-solid/test/rules/no-async-effect-half.test.ts
@@ -1,0 +1,60 @@
+import { run } from "../ruleTester";
+import rule from "../../src/rules/no-async-effect-half";
+
+export const cases = run("no-async-effect-half", rule, {
+  valid: [
+    `import { createEffect } from "solid-js";
+createEffect(() => count(), (value) => console.log(value));`,
+    // async computations are first-class; only the effect half must be sync
+    `import { createEffect } from "solid-js";
+createEffect(async () => (await fetch(url())).json(), (data) => setData(data));`,
+    `import { createEffect } from "solid-js";
+createEffect(() => query(), (q) => {
+  const controller = new AbortController();
+  fetch(q, { signal: controller.signal }).then(handle);
+  return () => controller.abort();
+});`,
+    // single-argument form is solid/no-single-arg-create-effect's territory
+    `import { createEffect } from "solid-js";
+createEffect(async () => console.log(await promise));`,
+    `import { createEffect } from "solid-js";
+const log = (value) => console.log(value);
+createEffect(() => count(), log);`,
+  ],
+  invalid: [
+    {
+      code: `import { createEffect } from "solid-js";
+createEffect(() => query(), async (q) => {
+  const data = await fetch(q);
+  setData(data);
+});`,
+      errors: [{ messageId: "asyncEffect" }],
+    },
+    {
+      code: `import { createEffect } from "solid-js";
+createEffect(() => query(), async function (q) {
+  await save(q);
+});`,
+      errors: [{ messageId: "asyncEffect" }],
+    },
+    {
+      code: `import { createRenderEffect } from "solid-js";
+createRenderEffect(() => count(), async (value) => update(await value));`,
+      errors: [{ messageId: "asyncEffect" }],
+    },
+    {
+      code: `import { createEffect } from "solid-js";
+async function persist(value) {
+  await save(value);
+}
+createEffect(() => count(), persist);`,
+      errors: [{ messageId: "asyncEffect" }],
+    },
+    {
+      code: `import { createEffect } from "solid-js";
+const persist = async (value) => save(value);
+createEffect(() => count(), persist);`,
+      errors: [{ messageId: "asyncEffect" }],
+    },
+  ],
+});

--- a/packages/eslint-plugin-solid/test/rules/no-store-mutation-outside-setter.imports.test.ts
+++ b/packages/eslint-plugin-solid/test/rules/no-store-mutation-outside-setter.imports.test.ts
@@ -1,0 +1,39 @@
+import { vi } from "vitest";
+
+// The global vitest setup mocks trackImports so most rule tests can skip
+// import boilerplate. These cases exercise the real import gating — foreign
+// createStores excluded, Solid aliases resolved — so restore it here. This
+// file is intentionally not named `<rule>.test.ts`: scripts/docs.mts imports
+// test files by that name to build docs and cannot load files using vitest
+// APIs.
+vi.unmock("../../src/utils");
+
+import { run } from "../ruleTester";
+import rule from "../../src/rules/no-store-mutation-outside-setter";
+
+export const cases = run("no-store-mutation-outside-setter", rule, {
+  valid: [
+    // not Solid's createStore
+    `import { createStore } from "another-library";
+const [store, setStore] = createStore({ count: 0 });
+store.count = 5;`,
+    `const createStore = (init) => [init, () => {}];
+const [store, setStore] = createStore({ count: 0 });
+store.count++;`,
+  ],
+  invalid: [
+    {
+      code: `import { createStore as makeStore } from "solid-js";
+const [store, setStore] = makeStore({ count: 0 });
+store.count = 5;`,
+      errors: [{ messageId: "mutateStore" }],
+    },
+    // createStore is importable from "solid-js/store" for compatibility
+    {
+      code: `import { createStore } from "solid-js/store";
+const [store, setStore] = createStore({ items: [] });
+store.items.push(1);`,
+      errors: [{ messageId: "mutateStore" }],
+    },
+  ],
+});

--- a/packages/eslint-plugin-solid/test/rules/no-store-mutation-outside-setter.test.ts
+++ b/packages/eslint-plugin-solid/test/rules/no-store-mutation-outside-setter.test.ts
@@ -1,0 +1,82 @@
+import { run } from "../ruleTester";
+import rule from "../../src/rules/no-store-mutation-outside-setter";
+
+export const cases = run("no-store-mutation-outside-setter", rule, {
+  valid: [
+    `import { createStore } from "solid-js";
+const [store, setStore] = createStore({ count: 0 });
+setStore((draft) => {
+  draft.count++;
+});
+console.log(store.count);`,
+    // a shadowing parameter is the draft, not the read proxy
+    `import { createStore } from "solid-js";
+const [store, setStore] = createStore({ count: 0 });
+setStore((store) => {
+  store.count = 5;
+});`,
+    // snapshots are plain data and free to mutate
+    `import { createStore, snapshot } from "solid-js";
+const [store, setStore] = createStore({ items: [] });
+const copy = snapshot(store);
+copy.items.push(1);`,
+    // non-mutating methods read through the proxy
+    `import { createStore } from "solid-js";
+const [store, setStore] = createStore({ items: [] });
+const doubled = store.items.map((n) => n * 2);
+setStore((draft) => (draft.items = doubled));`,
+    // plain objects are not stores
+    `const obj = { count: 0 };
+obj.count++;
+delete obj.count;`,
+  ],
+  invalid: [
+    {
+      code: `import { createStore } from "solid-js";
+const [store, setStore] = createStore({ count: 0 });
+store.count = 5;`,
+      errors: [{ messageId: "mutateStore" }],
+    },
+    {
+      code: `import { createStore } from "solid-js";
+const [store, setStore] = createStore({ count: 0 });
+store.count++;`,
+      errors: [{ messageId: "mutateStore" }],
+    },
+    {
+      code: `import { createStore } from "solid-js";
+const [store, setStore] = createStore({ items: [] });
+store.items.push(item);`,
+      errors: [{ messageId: "mutateStore" }],
+    },
+    {
+      code: `import { createStore } from "solid-js";
+const [store, setStore] = createStore({ user: { name: "a" } });
+delete store.user.name;`,
+      errors: [{ messageId: "mutateStore" }],
+    },
+    {
+      code: `import { createStore } from "solid-js";
+const [store, setStore] = createStore({ nested: { deep: { value: 0 } } });
+store.nested.deep.value = 1;`,
+      errors: [{ messageId: "mutateStore" }],
+    },
+    // mutating the read proxy is wrong even inside the setter — use the draft
+    {
+      code: `import { createStore } from "solid-js";
+const [store, setStore] = createStore({ count: 0 });
+setStore(() => {
+  store.count = 5;
+});`,
+      errors: [{ messageId: "mutateStore" }],
+    },
+    {
+      code: `import { createProjection } from "solid-js";
+const selected = createProjection((draft) => {
+  draft[selectedId()] = true;
+});
+selected.other = true;`,
+      errors: [{ messageId: "mutateProjection" }],
+    },
+  ],
+});

--- a/packages/eslint-plugin-solid/test/rules/no-unused-signal.imports.test.ts
+++ b/packages/eslint-plugin-solid/test/rules/no-unused-signal.imports.test.ts
@@ -1,0 +1,32 @@
+import { vi } from "vitest";
+
+// The global vitest setup mocks trackImports so most rule tests can skip
+// import boilerplate. These cases exercise the real import gating — foreign
+// createSignals excluded, Solid aliases resolved — so restore it here. This
+// file is intentionally not named `<rule>.test.ts`: scripts/docs.mts imports
+// test files by that name to build docs and cannot load files using vitest
+// APIs.
+vi.unmock("../../src/utils");
+
+import { run } from "../ruleTester";
+import rule from "../../src/rules/no-unused-signal";
+
+export const cases = run("no-unused-signal", rule, {
+  valid: [
+    // not Solid's createSignal
+    `const createSignal = (v) => [() => v, () => {}];
+const [count, setCount] = createSignal(0);
+console.log(count());`,
+    `import { createSignal } from "another-library";
+const [count, setCount] = createSignal(0);
+console.log(count());`,
+  ],
+  invalid: [
+    {
+      code: `import { createSignal as signal } from "solid-js";
+const [count, setCount] = signal(0);
+setCount(5);`,
+      errors: [{ messageId: "neverRead" }],
+    },
+  ],
+});

--- a/packages/eslint-plugin-solid/test/rules/no-unused-signal.test.ts
+++ b/packages/eslint-plugin-solid/test/rules/no-unused-signal.test.ts
@@ -1,0 +1,81 @@
+import { run } from "../ruleTester";
+import rule from "../../src/rules/no-unused-signal";
+
+export const cases = run("no-unused-signal", rule, {
+  valid: [
+    `import { createSignal } from "solid-js";
+const [count, setCount] = createSignal(0);
+console.log(count());
+setCount(1);`,
+    // passing either half along counts as a use
+    `import { createSignal } from "solid-js";
+function Counter() {
+  const [count, setCount] = createSignal(0);
+  return <Child value={count} onIncrement={setCount} />;
+}`,
+    // exported signals can be read or written by other modules
+    `import { createSignal } from "solid-js";
+export const [theme, setTheme] = createSignal("light");`,
+    // the whole tuple is the handle; nothing to prove here
+    `import { createSignal } from "solid-js";
+const tuple = createSignal(0);
+use(tuple);`,
+  ],
+  invalid: [
+    {
+      code: `import { createSignal } from "solid-js";
+const [count, setCount] = createSignal(0);
+console.log(count());`,
+      errors: [
+        {
+          messageId: "neverWritten",
+          suggestions: [
+            {
+              messageId: "replaceWithAccessor",
+              output: `import { createSignal } from "solid-js";
+const count = () => 0;
+console.log(count());`,
+            },
+          ],
+        },
+      ],
+    },
+    {
+      code: `import { createSignal } from "solid-js";
+const [count] = createSignal(0);
+console.log(count());`,
+      errors: [
+        {
+          messageId: "neverWritten",
+          suggestions: [
+            {
+              messageId: "replaceWithAccessor",
+              output: `import { createSignal } from "solid-js";
+const count = () => 0;
+console.log(count());`,
+            },
+          ],
+        },
+      ],
+    },
+    // non-literal initializer: report without a suggestion
+    {
+      code: `import { createSignal } from "solid-js";
+const [items, setItems] = createSignal([]);
+console.log(items());`,
+      errors: [{ messageId: "neverWritten" }],
+    },
+    {
+      code: `import { createSignal } from "solid-js";
+const [count, setCount] = createSignal(0);
+setCount(5);`,
+      errors: [{ messageId: "neverRead" }],
+    },
+    {
+      code: `import { createSignal } from "solid-js";
+const [, setCount] = createSignal(0);
+setCount(5);`,
+      errors: [{ messageId: "neverRead" }],
+    },
+  ],
+});

--- a/packages/eslint-plugin-solid/test/rules/no-write-in-pure-computation.imports.test.ts
+++ b/packages/eslint-plugin-solid/test/rules/no-write-in-pure-computation.imports.test.ts
@@ -1,0 +1,33 @@
+import { vi } from "vitest";
+
+// The global vitest setup mocks trackImports so most rule tests can skip
+// import boilerplate. These cases exercise the real import gating — foreign
+// createMemos excluded, Solid aliases resolved — so restore it here. This
+// file is intentionally not named `<rule>.test.ts`: scripts/docs.mts imports
+// test files by that name to build docs and cannot load files using vitest
+// APIs.
+vi.unmock("../../src/utils");
+
+import { run } from "../ruleTester";
+import rule from "../../src/rules/no-write-in-pure-computation";
+
+export const cases = run("no-write-in-pure-computation", rule, {
+  valid: [
+    // not Solid's createMemo
+    `import { createSignal } from "solid-js";
+import { createMemo } from "another-library";
+const [count, setCount] = createSignal(0);
+const bad = createMemo(() => setCount(1));`,
+  ],
+  invalid: [
+    {
+      code: `import { createSignal as signal, createMemo as memo } from "solid-js";
+const [count, setCount] = signal(0);
+const bad = memo(() => {
+  setCount(count() + 1);
+  return count();
+});`,
+      errors: [{ messageId: "writeInMemo" }],
+    },
+  ],
+});

--- a/packages/eslint-plugin-solid/test/rules/no-write-in-pure-computation.test.ts
+++ b/packages/eslint-plugin-solid/test/rules/no-write-in-pure-computation.test.ts
@@ -1,0 +1,65 @@
+import { run } from "../ruleTester";
+import rule from "../../src/rules/no-write-in-pure-computation";
+
+export const cases = run("no-write-in-pure-computation", rule, {
+  valid: [
+    // the effect half is the sanctioned place for writes
+    `import { createSignal, createEffect } from "solid-js";
+const [count, setCount] = createSignal(0);
+const [double, setDouble] = createSignal(0);
+createEffect(() => count(), (value) => setDouble(value * 2));`,
+    // event handlers and other deferred functions write outside the computation
+    `import { createSignal, createMemo } from "solid-js";
+const [count, setCount] = createSignal(0);
+const handler = createMemo(() => () => setCount(count() + 1));`,
+    `import { createSignal } from "solid-js";
+const [count, setCount] = createSignal(0);
+setCount(5);`,
+    // reads inside a memo are what memos are for
+    `import { createSignal, createMemo } from "solid-js";
+const [count, setCount] = createSignal(0);
+const double = createMemo(() => count() * 2);`,
+    // functions that aren't tuple setters are not writes
+    `import { createMemo } from "solid-js";
+const result = createMemo(() => transform(input()));`,
+  ],
+  invalid: [
+    {
+      code: `import { createSignal, createMemo } from "solid-js";
+const [count, setCount] = createSignal(0);
+const bad = createMemo(() => {
+  setCount(count() + 1);
+  return count();
+});`,
+      errors: [{ messageId: "writeInMemo" }],
+    },
+    {
+      code: `import { createSignal, createEffect } from "solid-js";
+const [log, setLog] = createSignal("");
+createEffect(() => {
+  setLog(query());
+  return query();
+}, (value) => console.log(value));`,
+      errors: [{ messageId: "writeInCompute" }],
+    },
+    {
+      code: `import { createSignal, createRenderEffect } from "solid-js";
+const [size, setSize] = createSignal(0);
+createRenderEffect(() => {
+  setSize(width());
+  return width();
+}, (value) => update(value));`,
+      errors: [{ messageId: "writeInCompute" }],
+    },
+    // store setters are writes too
+    {
+      code: `import { createStore, createMemo } from "solid-js";
+const [store, setStore] = createStore({ count: 0 });
+const bad = createMemo(() => {
+  setStore((draft) => draft.count++);
+  return store.count;
+});`,
+      errors: [{ messageId: "writeInMemo" }],
+    },
+  ],
+});


### PR DESCRIPTION
Adds four rules targeting Solid 2.0 semantics, continuing from the server function rules in #218.

## New rules

- **`solid/no-async-effect-half`** (error in `v2`) — an `async` function as the effect half of `createEffect(compute, effect)` returns a Promise, so its cleanup return value is silently discarded and code after `await` runs outside the effect's lifecycle. The compute half is exempt (async computations are first-class). Resolves identifiers to async function declarations/expressions too.
- **`solid/no-write-in-pure-computation`** (error in `v2`) — setter calls inside `createMemo` callbacks or the compute half of `createEffect`/`createRenderEffect`, which are pure tracked computations; writes there create update cycles and throw in 2.0 dev. Only setter calls whose *nearest enclosing function* is the computation are flagged, so returned handlers and nested callbacks never false-positive.
- **`solid/no-store-mutation-outside-setter`** (error in `v2`) — mutating a store's read proxy (`store.count++`, `store.items.push(x)`, `delete store.x`) throws in dev and silently fails to trigger updates otherwise; state changes go through the setter's mutable draft. Also flags mutating a `createProjection` result with its own message. Draft parameters (even ones shadowing the store's name), `snapshot()` copies, and plain objects resolve elsewhere and are naturally exempt.
- **`solid/no-unused-signal`** (warn in `v2`, error in `v2-strict`) — a destructured signal tuple is the only handle on the signal, so scope analysis is conclusive: a setter never referenced means the value can never change (use a plain constant or `createMemo`), an accessor never referenced means dead state. Exported declarations are skipped. Includes an editor suggestion rewriting literal-initialized never-written signals to a constant accessor.

## Notes

- Alias/shadow import gating is covered in `*.imports.test.ts` files that `vi.unmock` `trackImports`, following the existing `no-restated-default-options.imports.test.ts` convention.
- Docs generated with `turbo:docs`; README config descriptions and rule table updated, root README synced.
- Smoke-tested against a real Solid 2.0 RC project through both ESLint and Oxlint's JS-plugin bridge; caught genuine bugs (a write-only signal, a setter call inside `createMemo`) with no false positives across the rest of the codebase.

Tests: 2236 pass across typescript-eslint, @babel/eslint-parser, and espree (`PARSER=all`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)