### PR TITLE
fix: map the JSX type to @solidjs/web in Solid 2.0 imports rule

### DIFF
--- a/packages/eslint-plugin-solid/docs/imports.md
+++ b/packages/eslint-plugin-solid/docs/imports.md
@@ -62,6 +62,15 @@ import { createSignal } from "@solidjs/web";
 // after eslint --fix:
 import { createSignal } from "solid-js";
 
+import type { JSX } from "solid-js";
+// after eslint --fix:
+import type { JSX } from "@solidjs/web";
+
+import type { JSX, Component } from "solid-js";
+// after eslint --fix:
+import type { JSX } from "@solidjs/web";
+import type { Component } from "solid-js";
+
 ```
 
 ### Valid Examples
@@ -93,6 +102,9 @@ import { createSignal, createStore, reconcile, merge } from "solid-js";
 import { render, Portal, Dynamic, isServer } from "@solidjs/web";
 
 import { createStore } from "solid-js/store";
+
+import type { Component } from "solid-js";
+import type { JSX } from "@solidjs/web";
 
 ```
 <!-- end-doc-gen -->

--- a/packages/eslint-plugin-solid/src/rules/imports.ts
+++ b/packages/eslint-plugin-solid/src/rules/imports.ts
@@ -222,7 +222,6 @@ for (const type of [
   "ValidComponent",
   "ComponentProps",
   "Context",
-  "JSX",
   "ResolvedChildren",
   "Store",
   "StoreNode",
@@ -234,6 +233,10 @@ for (const type of [
   "Owner",
 ]) {
   typeMapV2.set(type, "solid-js");
+}
+// The JSX namespace moved out of core: in Solid 2.0 it is only exported by "@solidjs/web".
+for (const type of ["JSX"]) {
+  typeMapV2.set(type, "@solidjs/web");
 }
 
 const sourceRegex = /^solid-js(?:\/web|\/store)?$/;

--- a/packages/eslint-plugin-solid/test/rules/imports.test.ts
+++ b/packages/eslint-plugin-solid/test/rules/imports.test.ts
@@ -32,6 +32,13 @@ import type { Store } from "solid-js/store";`,
       code: `import { createStore } from "solid-js/store";`,
       settings: { solid: { version: 2 } },
     },
+    {
+      // Solid 2.0: the JSX namespace is only exported by "@solidjs/web"
+      code: `import type { Component } from "solid-js";
+import type { JSX } from "@solidjs/web";`,
+      settings: { solid: { version: 2 } },
+      [tsOnly]: true,
+    },
   ],
   invalid: [
     {
@@ -152,6 +159,33 @@ import {  createEffect } from "solid-js";`,
       ],
       output: `import { createSignal } from "solid-js";
 `,
+    },
+    // Solid 2.0: the JSX namespace is only exported by "@solidjs/web", not core
+    {
+      code: `import type { JSX } from "solid-js";`,
+      settings: { solid: { version: 2 } },
+      [tsOnly]: true,
+      errors: [
+        {
+          messageId: "prefer-source",
+          data: { name: "JSX", source: "@solidjs/web" },
+        },
+      ],
+      output: `import type { JSX } from "@solidjs/web";
+`,
+    },
+    {
+      code: `import type { JSX, Component } from "solid-js";`,
+      settings: { solid: { version: 2 } },
+      [tsOnly]: true,
+      errors: [
+        {
+          messageId: "prefer-source",
+          data: { name: "JSX", source: "@solidjs/web" },
+        },
+      ],
+      output: `import type { JSX } from "@solidjs/web";
+import type {  Component } from "solid-js";`,
     },
   ],
 });


### PR DESCRIPTION
## Summary

- In Solid 2.0 the `JSX` namespace is no longer exported from `solid-js`; it only lives in `@solidjs/web`. With `settings.solid.version: 2`, `solid/imports` was reporting `import type { JSX } from "@solidjs/web"` with "Prefer importing JSX from solid-js" and autofixing it into a module that doesn't export it.
- Moves `JSX` out of the v2 `solid-js` type list into a new `@solidjs/web` type list. The 1.x map is unchanged, since `solid-js` 1.x does export `JSX`.
- Adds v2 tests: importing `JSX` from `@solidjs/web` is valid; importing it from `solid-js` is reported and autofixed, both alone and alongside `Component` (which stays on `solid-js`).
- Regenerates `docs/imports.md` from the tests.

Verified against the published `solid-js@2.0.0-rc.6` and `@solidjs/web@2.0.0-rc.6` type declarations: every other entry in the v2 type map still resolves to `solid-js`, and `@solidjs/web` re-exports `JSX` from its index.

Not addressed here: `renderToStringAsync` no longer exists in `@solidjs/web` rc.6, so the v2 value map entry for it points at a name with no valid home. That's a removed API rather than a misplaced one and probably belongs in `solid/removed-api`.

## Test plan

- [x] `PARSER=all vitest --run test/rules/imports.test.ts` (typescript-eslint, babel, espree)
- [x] Full plugin suite: 707 tests across 32 files pass
- [x] `eslint --max-warnings=0` on the changed files
- [x] `tsc`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
