### PR TITLE
0.17.1: staleCapture regression, imports type maps, renderToStringAsync

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,7 +265,7 @@ If you want to pin a minor version, use a tilde in your `package.json`.
 
 <!-- doc-gen TILDE -->
 ```diff
-- "eslint-plugin-solid": "^0.17.0"
-+ "eslint-plugin-solid": "~0.17.0"
+- "eslint-plugin-solid": "^0.17.1"
++ "eslint-plugin-solid": "~0.17.1"
 ```
 <!-- end-doc-gen -->

--- a/packages/eslint-plugin-solid/CHANGELOG.md
+++ b/packages/eslint-plugin-solid/CHANGELOG.md
@@ -1,5 +1,31 @@
 # Changelog
 
+## 0.17.1
+
+Bug fixes only. Thanks to @jynxio and @brenelz for the reports and PRs.
+
+### Fixes
+
+- **`solid/reactivity` regression from 0.16.1** (#223). The `staleCapture` check flagged captures
+  read inside synchronous array-method callbacks (`items.filter((item) => item.includes(q))`)
+  within `createMemo`/`createEffect` bodies. A function passed as a call argument doesn't escape
+  through a `return` below it — only the call's result does — so these callbacks run during the
+  computation, where the capture is fresh. IIFEs are exempt for the same reason.
+- **`solid/imports` type mappings for Solid 2.0** (#220, #221, #222). The `JSX` namespace only
+  exists in `@solidjs/web` in 2.0; the rule was autofixing correct imports into a module that
+  doesn't export it. `ValidComponent`/`ComponentProps` are now accepted from both `solid-js`
+  (DOM-independent) and `@solidjs/web` (DOM-aware) since the two packages export genuinely
+  different types. The fixer also no longer produces a duplicate `type` modifier
+  (`import type { type JSX }`) when moving inline type specifiers.
+- **`renderToStringAsync` is a removed API, not a misplaced one** (#222 follow-up). It no longer
+  exists in Solid 2.0 (`renderToString` awaits async content). Dropped from the v2 imports map —
+  which was autofixing imports into a dead end — and added to `solid/removed-api` with migration
+  guidance. `solid/removed-api` now also scans `@solidjs/web` imports, so a mechanically
+  source-rewritten import of a removed API is still reported.
+
+Also verified fixed and closed: #193 (signals passed as `create*` arguments stopped warning with
+the 0.16.1 accessor-passing work).
+
 ## 0.17.0
 
 Server functions are core in Solid 2.0, so the plugin now lints them. Four new rules cover the

--- a/packages/eslint-plugin-solid/README.md
+++ b/packages/eslint-plugin-solid/README.md
@@ -265,7 +265,7 @@ If you want to pin a minor version, use a tilde in your `package.json`.
 
 <!-- doc-gen TILDE -->
 ```diff
-- "eslint-plugin-solid": "^0.17.0"
-+ "eslint-plugin-solid": "~0.17.0"
+- "eslint-plugin-solid": "^0.17.1"
++ "eslint-plugin-solid": "~0.17.1"
 ```
 <!-- end-doc-gen -->

--- a/packages/eslint-plugin-solid/docs/imports.md
+++ b/packages/eslint-plugin-solid/docs/imports.md
@@ -62,6 +62,11 @@ import type { JSX } from "solid-js";
 // after eslint --fix:
 import type { JSX } from "@solidjs/web";
 
+import type { JSX, Component } from "solid-js";
+// after eslint --fix:
+import type { JSX } from "@solidjs/web";
+import type { Component } from "solid-js";
+
 import { render } from "solid-js";
 // after eslint --fix:
 import { render } from "@solidjs/web";

--- a/packages/eslint-plugin-solid/docs/reactivity.md
+++ b/packages/eslint-plugin-solid/docs/reactivity.md
@@ -1324,6 +1324,32 @@ function useTotal() {
   return () => items().length;
 }
 
+const ITEMS = ["alpha", "beta", "gamma"];
+function Filtered() {
+  const [query, setQuery] = createSignal("");
+  const matches = createMemo(() => {
+    const q = query().toUpperCase();
+    return ITEMS.filter((item) => item.toUpperCase().includes(q));
+  });
+  return <div>{matches().length}</div>;
+}
+
+const ITEMS = ["alpha", "beta"];
+function Component() {
+  const [query, setQuery] = createSignal("");
+  createEffect(() => {
+    const q = query();
+    console.log(ITEMS.some((item) => item === q));
+  });
+  return <div />;
+}
+
+const [count, setCount] = createSignal(0);
+function useLabel() {
+  const value = count();
+  return (() => "count: " + value)();
+}
+
 ```
 <!-- end-doc-gen -->
 

--- a/packages/eslint-plugin-solid/docs/removed-api.md
+++ b/packages/eslint-plugin-solid/docs/removed-api.md
@@ -53,6 +53,12 @@ import { on, useTransition } from "solid-js";
 
 import { Index, Suspense, ErrorBoundary } from "solid-js";
 
+import { renderToStringAsync } from "@solidjs/web";
+
+import { renderToStringAsync } from "solid-js/web";
+// after eslint --fix:
+import { renderToStringAsync } from "@solidjs/web";
+
 import { render } from "solid-js/web";
 // after eslint --fix:
 import { render } from "@solidjs/web";

--- a/packages/eslint-plugin-solid/package.json
+++ b/packages/eslint-plugin-solid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-solid",
-  "version": "0.17.0",
+  "version": "0.17.1",
   "description": "Solid-specific linting rules for ESLint.",
   "keywords": [
     "eslint",

--- a/packages/eslint-plugin-solid/src/rules/imports.ts
+++ b/packages/eslint-plugin-solid/src/rules/imports.ts
@@ -206,7 +206,7 @@ for (const primitive of [
   "isServer",
   "renderToString",
   "renderToStream",
-  "renderToStringAsync",
+  // renderToStringAsync no longer exists in 2.0 (removed-api reports it)
   "generateHydrationScript",
   "HydrationScript",
 ]) {

--- a/packages/eslint-plugin-solid/src/rules/reactivity.ts
+++ b/packages/eslint-plugin-solid/src/rules/reactivity.ts
@@ -541,6 +541,12 @@ export default createRule<Options, MessageIds>({
       let parent: T.Node | null = child.parent ?? null;
       while (parent && child !== boundary) {
         if (parent.type === "ReturnStatement") return true;
+        // A function passed as a call argument doesn't escape through a
+        // `return` below it — only the call's *result* does. Synchronous
+        // callbacks (`return items.filter((item) => item.includes(q))`) run
+        // during the computation, where the capture is fresh (#223). The
+        // same goes for a called function itself (IIFEs).
+        if (parent.type === "CallExpression" || parent.type === "NewExpression") return false;
         if (isFunctionNode(parent)) {
           return (
             parent === boundary &&

--- a/packages/eslint-plugin-solid/src/rules/removed-api.ts
+++ b/packages/eslint-plugin-solid/src/rules/removed-api.ts
@@ -54,6 +54,10 @@ const REMOVED = new Map<string, string>([
     "splitProps",
     'Use `omit` from "solid-js" to exclude props, and pass the original props object along',
   ],
+  [
+    "renderToStringAsync",
+    "`renderToString` awaits async content in Solid 2.0; use it (or `renderToStream`) instead",
+  ],
   ["createMutable", "Use `createStore`; store setters mutate directly in Solid 2.0"],
   ["modifyMutable", "Use `createStore`; store setters mutate directly in Solid 2.0"],
   [
@@ -70,7 +74,9 @@ const REMOVED = new Map<string, string>([
 // Exports that moved from "solid-js/store" into core "solid-js" unchanged.
 const STORE_MOVED = new Set(["createStore", "reconcile", "Store", "StoreNode"]);
 
-const SOLID_SOURCE_REGEX = /^solid-js(?:\/web|\/store)?$/;
+// Includes "@solidjs/web" so 1.x APIs that survived a mechanical source
+// rewrite (e.g. renderToStringAsync) are still reported as removed.
+const SOLID_SOURCE_REGEX = /^(?:solid-js(?:\/web|\/store)?|@solidjs\/web)$/;
 
 type MessageIds = "renamed" | "removed" | "webMoved" | "storeMoved" | "classList";
 type Options = [];

--- a/packages/eslint-plugin-solid/test/rules/imports.test.ts
+++ b/packages/eslint-plugin-solid/test/rules/imports.test.ts
@@ -165,6 +165,20 @@ import {  createEffect } from "solid-js";`,
       output: `import type { JSX } from "@solidjs/web";
 `,
     },
+    // JSX moves out while Component stays on solid-js
+    {
+      code: `import type { JSX, Component } from "solid-js";`,
+      settings: { solid: { version: 2 } },
+      [tsOnly]: true,
+      errors: [
+        {
+          messageId: "prefer-source",
+          data: { name: "JSX", source: "@solidjs/web" },
+        },
+      ],
+      output: `import type { JSX } from "@solidjs/web";
+import type {  Component } from "solid-js";`,
+    },
     {
       code: `import { render } from "solid-js";`,
       settings: { solid: { version: 2 } },

--- a/packages/eslint-plugin-solid/test/rules/reactivity.test.ts
+++ b/packages/eslint-plugin-solid/test/rules/reactivity.test.ts
@@ -604,6 +604,33 @@ export const cases = run("reactivity", rule, {
       console.log(list);
       return () => items().length;
     }`,
+    // A capture read by a synchronous array-method callback runs during the
+    // computation, where it is fresh — the callback doesn't escape through
+    // the return; only the call's result does (#223)
+    `const ITEMS = ["alpha", "beta", "gamma"];
+    function Filtered() {
+      const [query, setQuery] = createSignal("");
+      const matches = createMemo(() => {
+        const q = query().toUpperCase();
+        return ITEMS.filter((item) => item.toUpperCase().includes(q));
+      });
+      return <div>{matches().length}</div>;
+    }`,
+    `const ITEMS = ["alpha", "beta"];
+    function Component() {
+      const [query, setQuery] = createSignal("");
+      createEffect(() => {
+        const q = query();
+        console.log(ITEMS.some((item) => item === q));
+      });
+      return <div />;
+    }`,
+    // IIFEs run during the computation too
+    `const [count, setCount] = createSignal(0);
+    function useLabel() {
+      const value = count();
+      return (() => "count: " + value)();
+    }`,
   ],
   invalid: [
     // Untracked signals

--- a/packages/eslint-plugin-solid/test/rules/removed-api.test.ts
+++ b/packages/eslint-plugin-solid/test/rules/removed-api.test.ts
@@ -56,6 +56,17 @@ om(() => {});`,
       code: `import { Index, Suspense, ErrorBoundary } from "solid-js";`,
       errors: [{ messageId: "removed" }, { messageId: "removed" }, { messageId: "removed" }],
     },
+    // removed APIs are reported from "@solidjs/web" too, so a mechanical
+    // source rewrite doesn't hide them (#222)
+    {
+      code: `import { renderToStringAsync } from "@solidjs/web";`,
+      errors: [{ messageId: "removed" }],
+    },
+    {
+      code: `import { renderToStringAsync } from "solid-js/web";`,
+      errors: [{ messageId: "removed" }, { messageId: "webMoved" }],
+      output: `import { renderToStringAsync } from "@solidjs/web";`,
+    },
     // module moves
     {
       code: `import { render } from "solid-js/web";`,

--- a/packages/eslint-solid-standalone/package.json
+++ b/packages/eslint-solid-standalone/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-solid-standalone",
-  "version": "0.17.0",
+  "version": "0.17.1",
   "description": "A bundle with eslint and eslint-plugin-solid that can be used in the browser.",
   "repository": "https://github.com/solidjs-community/eslint-plugin-solid",
   "license": "MIT",


### PR DESCRIPTION
## Summary

Bug-fix patch, no new rules.

- **Fixes #223** — `staleCapture` regression from 0.16.1: a function passed as a call argument doesn't escape through a `return` below it, so synchronous array-method callbacks (`items.filter((item) => item.includes(q))`) and IIFEs inside `createMemo`/`createEffect` no longer flag. Regression tests from the issue repro, all four original staleCapture detections preserved.
- **Follows up #220/#221/#222** — ports the mixed `JSX, Component` split test from #222; moves `renderToStringAsync` out of the v2 imports map (it was autofixing imports into a dead end) and into `solid/removed-api` with guidance (`renderToString` awaits async content in 2.0). `removed-api` now also scans `@solidjs/web` imports so mechanically source-rewritten imports of removed APIs are still reported.
- Changelog + version bump to 0.17.1.

Also verified #193 fixed (closed) — signals passed as `create*` arguments stopped warning with the 0.16.1 accessor-passing work.

## Test plan

- [x] `PARSER=all`: full plugin suite passes on typescript-eslint, babel, espree
- [x] Self-lint clean, `tsc` clean
- [x] Solid 2.0 template fixtures + sibling-checkout sweep: zero findings

Made with [Cursor](https://cursor.com)